### PR TITLE
Improve currency function

### DIFF
--- a/src/views/CustomTip.vue
+++ b/src/views/CustomTip.vue
@@ -18,21 +18,31 @@ const onlyForCurrency = ($event: any) => {
         return;
     }
 
-    // restrict to 2 decimal places
+    // restrict to 2 decimal places and 1 digit in integer part
     if (paymentStore.tip !== null && paymentStore.tip !== undefined) {
-        const parts = paymentStore.tip.toString().split('.');
+        const currentTip = paymentStore.tip.toString();
+        const parts = currentTip.split('.');
+
+        // Check total number of digits
+        const totalDigits = currentTip.replace('.', '').length;
+        if (totalDigits >= 3 || (parts[0].length > 0 && parseInt(parts[0]) > 9)) {
+            $event.preventDefault();
+            return;
+        }
 
         if (parts.length > 1) {
             const decimalPart = parts[1];
-            const hasMoreThanTwoDecimals = decimalPart?.length > 2;
-            const hasLeadingZeros = decimalPart?.startsWith('0') && decimalPart !== '0';
 
-            if (hasMoreThanTwoDecimals || hasLeadingZeros) {
+            // prevent more than two decimal places
+            if (decimalPart.length >= 2) {
                 $event.preventDefault();
+                return;
             }
         }
     }
 };
+
+
 
 const roundValue = () => {
     if (paymentStore.tip !== null && paymentStore.tip !== undefined) {


### PR DESCRIPTION
# Type of change

<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Description
<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
Express your concerns about your changes if you have any.
If your changes are dependent to changes to another repo (backend or frontend) please link it.
Same for other open branches your branch might depends on.
-->
This adds a check that the user can only type in two digits like "99" and something like "123789129" is not possible anymore.
Leading zeros are still possible like "0.00009" or "000012" but this does not lead to any overflow in the following confirmation page. So for now I do not care about this but write this as a TODO in our Issues.

# Checklist:

- [x] I have commented my code (or ChatGPT did), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings, neither in my IDE nor in my browser
- [ ] I have added tests that prove my fix is effective or that my feature works