### PR TITLE
Fix router guard, watcher leak, and abonement modal guard

### DIFF
--- a/src/composables/useAuthLoad.ts
+++ b/src/composables/useAuthLoad.ts
@@ -1,4 +1,4 @@
-import { computed, watch } from 'vue'
+import { computed, onUnmounted, watch } from 'vue'
 import { useKeycloakStore } from '@/stores/keycloak'
 
 /**
@@ -10,11 +10,13 @@ export function useAuthLoad(load: () => void | Promise<void>) {
   const keycloakStore = useKeycloakStore()
   const authenticated = computed(() => keycloakStore.authenticated)
 
-  watch(
+  const stop = watch(
     authenticated,
     (val) => {
       if (val) load()
     },
     { immediate: true }
   )
+
+  onUnmounted(stop)
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -421,7 +421,7 @@ router.afterEach((to) => {
 // Check if the user is authenticated
 router.beforeEach(async (to: RouteLocationNormalized) => {
   if (to.meta.requiresAuth && to.name !== '404') {
-    await isAuthenticated(to)
+    return await isAuthenticated(to)
   }
 })
 
@@ -437,9 +437,7 @@ async function isAuthenticated(to: RouteLocationNormalized) {
 
     const keycloakStore = useKeycloakStore()
 
-    keycloakStore.setAuthenticated(
-      keycloak.keycloak?.authenticated ? keycloak.keycloak.authenticated : false
-    )
+    keycloakStore.setAuthenticated(keycloak.keycloak?.authenticated ?? false)
 
     if (keycloak.keycloak?.tokenParsed) {
       keycloakStore.setUsername(keycloak.keycloak.tokenParsed.preferred_username)
@@ -447,18 +445,16 @@ async function isAuthenticated(to: RouteLocationNormalized) {
 
     if (keycloak.keycloak?.tokenParsed?.groups.includes('vendor')) {
       if (!to.path.startsWith('/me')) {
-        router.push('/me')
+        return { name: 'My Info' }
       }
     } else if (keycloak.keycloak?.tokenParsed?.groups.includes('backoffice')) {
       if (to.path.startsWith('/me')) {
-        router.push('/backoffice/vendorsummary')
+        return { name: 'Backoffice' }
       }
     }
-
-    return keycloak.keycloak?.authenticated
-  } else {
-    return keycloak.keycloak?.authenticated
   }
+
+  return keycloak.keycloak?.authenticated ?? false
 }
 
 export default router

--- a/src/views/backoffice/BackofficeCustomerUpdate.vue
+++ b/src/views/backoffice/BackofficeCustomerUpdate.vue
@@ -100,9 +100,12 @@ async function confirmDeleteCustomer() {
 }
 
 function openNewAbonement() {
+  const firstItem = items.value[0]
+  if (!firstItem) return
+
   editingAbonement.value = {
     customer_id: customerId.value ?? 0,
-    item_id: items.value[0]?.ID ?? 0,
+    item_id: firstItem.ID,
     from_date: new Date().toISOString().slice(0, 10),
     to_date: new Date(Date.now() + 365 * 24 * 3600 * 1000).toISOString().slice(0, 10),
     status: 'active'


### PR DESCRIPTION
- beforeEach now returns the result of isAuthenticated so unauthenticated users are blocked; router.push() inside the guard replaced with return route objects to avoid double-navigation
- useAuthLoad stores the watcher stop function and calls it via onUnmounted to prevent stale callbacks after the component is destroyed
- openNewAbonement guards against an empty items list before dereferencing items[0]

# Type of change

<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Description
<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
Express your concerns about your changes if you have any.
If your changes are dependent to changes to another repo (backend or frontend) please link it.
Same for other open branches your branch might depends on.
-->

# Checklist:

- [ ] I have commented my code (or ChatGPT did), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings, neither in my IDE nor in my browser
- [ ] I have added tests that prove my fix is effective or that my feature works