### PR TITLE
Add customer management UI and fix auth/router issues

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -164,6 +164,7 @@ export async function patchSettings(updatedSettings: Settings) {
   )
 
   formData.append('DigitalItemsUrl', updatedSettings.DigitalItemsUrl)
+  formData.append('AbonementUrl', updatedSettings.AbonementUrl)
 
   formData.append(
     'OrgaCoversTransactionCosts',

--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -277,6 +277,17 @@ defineExpose({ saveSettings })
           type="text"
         />
       </div>
+      <div>
+        <label class="block text-gray-700 text-sm font-bold mb-2 pt-3" for="abonementUrl"
+          >{{ $t('Abonement URL') }}:</label
+        >
+        <input
+          id="abonementUrl"
+          v-model="localSettings.AbonementUrl"
+          class="appearance-none border rounded w-full py-2 px-3 text-gray-700"
+          type="text"
+        />
+      </div>
     </div>
 
     <div class="mt-4 grid grid-cols-2 gap-4">

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -272,6 +272,8 @@
   "Access your": "Greife auf deine",
   "here.": "hier zu.",
   "accessDigitalItem": "Greife hier auf deine {itemName} zu",
+  "viewAbonement": "Dein Abonnement ansehen",
+  "Abonement URL": "Abonnement-URL",
   "Mail Templates": "E-Mail Vorlagen",
   "Name": "Name",
   "Subject": "Betreff",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -199,6 +199,8 @@
   "Access your": "Access your",
   "here.": "here.",
   "accessDigitalItem": "Access your {itemName} here",
+  "viewAbonement": "View your subscription",
+  "Abonement URL": "Abonement URL",
   "menuCustomers": "Customers",
   "customerDetails": "Customer Details",
   "newCustomer": "New Customer",

--- a/src/stores/payment.ts
+++ b/src/stores/payment.ts
@@ -55,9 +55,9 @@ export const usePaymentStore = defineStore('payment', {
     },
 
     //AGB
-    checkAgb() {
+    checkAgb(vendorId: string) {
       if (this.agbChecked) {
-        router.push({ name: 'Payment' })
+        router.push({ name: 'Payment', params: { id: vendorId } })
         return true
       }
 

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -31,6 +31,7 @@ export interface Settings {
   UseTipInsteadOfDonation: boolean
   ShopLanding: boolean | undefined
   DigitalItemsUrl: string
+  AbonementUrl: string
   edges?: any
   Keycloak: {
     Realm: string

--- a/src/views/FinalPurchaseConfirmation.vue
+++ b/src/views/FinalPurchaseConfirmation.vue
@@ -3,17 +3,18 @@ import { useShopStore } from '@/stores/ShopStore'
 import { usePaymentStore } from '@/stores/payment'
 import { useSettingsStore } from '@/stores/settings'
 import { ref, onMounted, computed } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import EmailModal from '@/components/EmailModal.vue'
 
 const router = useRouter()
+const route = useRoute()
 const shopStore = useShopStore()
 const settStore = useSettingsStore()
 const paymentStore = usePaymentStore()
 const shake = ref(false)
 
 const checkAgb = () => {
-  const agbsChecked = paymentStore.checkAgb()
+  const agbsChecked = paymentStore.checkAgb(route.params.id as string)
 
   if (!agbsChecked) {
     shake.value = true
@@ -35,13 +36,13 @@ onMounted(() => {
 })
 
 const hasLicenseItem = computed(() => {
-  const item = shopStore.items?.find((item) => item.LicenseItem != null)
-
-  if (item) {
-    if (shopStore.amount.find((i) => i.item == item.ID)) return item
-  }
-
-  return null
+  return (
+    shopStore.items?.find(
+      (item) =>
+        (item.LicenseItem != null || item.Type === 'abonement') &&
+        shopStore.amount.some((i) => i.item == item.ID)
+    ) ?? null
+  )
 })
 </script>
 

--- a/src/views/PaymentConfirmation.vue
+++ b/src/views/PaymentConfirmation.vue
@@ -34,8 +34,11 @@ const purchasedItems = computed(() => {
   if (!items) return []
 
   // Use a shallow copy to avoid mutating the original array and convert booleans to numbers for arithmetic
+  // Digital license items (non-abonement) go last; abonement items sort normally
   const tmp_items = [...items].sort(
-    (a, b) => Number(isLicenseItem(a.Item)) - Number(isLicenseItem(b.Item))
+    (a, b) =>
+      Number(isLicenseItem(a.Item) && !isAbonementItem(a.Item)) -
+      Number(isLicenseItem(b.Item) && !isAbonementItem(b.Item))
   )
 
   // duplicate items with quantity > 1
@@ -65,7 +68,7 @@ const digitalItems = computed(() => {
 
   return items.filter((item) => {
     const itemDetails = itemsStore.items?.find((i) => i.ID == item.Item)
-    return itemDetails && itemDetails.LicenseItem
+    return itemDetails && itemDetails.LicenseItem && itemDetails.Type !== 'abonement'
   })
 })
 
@@ -103,6 +106,15 @@ const isLicenseItem = (id: number) => {
   return item?.LicenseItem != null && item?.LicenseItem != undefined
 }
 
+const isAbonementItem = (id: number) => {
+  const item = itemsStore.items?.find((item) => item.ID == id)
+  return item?.Type === 'abonement'
+}
+
+const hasAbonementPurchase = computed(() =>
+  purchasedItems.value.some((item) => isAbonementItem(item.Item))
+)
+
 const itemDetails = (id: number) => {
   const item = itemsStore.items?.find((item) => item.ID == id)
   return item
@@ -119,6 +131,7 @@ const hasDigitalItemWithoutPDF = computed(() => {
     if (
       itemDetails &&
       itemDetails.LicenseItem &&
+      itemDetails.Type !== 'abonement' &&
       !downloadLinks.value?.some((link) => link.ItemID == item.Item)
     ) {
       return true
@@ -214,13 +227,13 @@ const email = localStorage.getItem('email') || ''
                 </div>
                 <div class="item-confirmation-icon">
                   <div
-                    v-if="isLicenseItem(item.Item)"
+                    v-if="isLicenseItem(item.Item) || isAbonementItem(item.Item)"
                     class="check-mark-success bg-white border-2 rounded-full h-15 w-15 fill-white right-0 top-0 place-items-center grid"
                   >
                     <IconDigitalIssue />
                   </div>
                   <div
-                    v-else-if="!isLicenseItem(item.Item) && item.Item !== DONATION_ITEM_ID"
+                    v-else-if="item.Item !== DONATION_ITEM_ID"
                     class="check-mark-success bg-green-600 rounded-full h-15 w-15 fill-white right-0 top-0 place-items-center grid"
                   >
                     <IconCheckmark />
@@ -266,6 +279,25 @@ const email = localStorage.getItem('email') || ''
                     itemName: digitalItems[0]?.Item ? itemDetails(digitalItems[0].Item)?.Name : ''
                   })
                 }}
+              </button>
+            </a>
+          </div>
+          <div v-if="hasAbonementPurchase && settStore.settings.AbonementUrl" class="abonement-link mt-3">
+            <a
+              :href="settStore.settings.AbonementUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <button
+                class="abonement-button rounded-full text-center p-5 customfont text-sm font-semibold w-full cursor-pointer"
+                :style="
+                  'background-color:' +
+                  settStore.settings.Color +
+                  '; color: ' +
+                  settStore.settings.FontColor
+                "
+              >
+                {{ $t('viewAbonement') }}
               </button>
             </a>
           </div>

--- a/src/views/PaymentConfirmation.vue
+++ b/src/views/PaymentConfirmation.vue
@@ -282,12 +282,11 @@ const email = localStorage.getItem('email') || ''
               </button>
             </a>
           </div>
-          <div v-if="hasAbonementPurchase && settStore.settings.AbonementUrl" class="abonement-link mt-3">
-            <a
-              :href="settStore.settings.AbonementUrl"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+          <div
+            v-if="hasAbonementPurchase && settStore.settings.AbonementUrl"
+            class="abonement-link mt-3"
+          >
+            <a :href="settStore.settings.AbonementUrl" target="_blank" rel="noopener noreferrer">
               <button
                 class="abonement-button rounded-full text-center p-5 customfont text-sm font-semibold w-full cursor-pointer"
                 :style="

--- a/src/views/backoffice/SettingsUpdate.vue
+++ b/src/views/backoffice/SettingsUpdate.vue
@@ -47,7 +47,8 @@ const updatedSettings = ref<Settings>({
   QRCodeEnableLogo: false,
   UseTipInsteadOfDonation: false,
   ShopLanding: false,
-  DigitalItemsUrl: ''
+  DigitalItemsUrl: '',
+  AbonementUrl: ''
 })
 
 useAuthLoad(() => {


### PR DESCRIPTION
## Summary

- **Customer management UI**: New backoffice views for listing, creating, editing, and deleting customers and their abonements, backed by a new Pinia customer store
- **`useAuthLoad` composable**: Replaces scattered `onMounted`/`onAuthSuccess` boilerplate across 16+ backoffice views with a single reactive watch, eliminating the race condition where data failed to load when Keycloak auth completed after component mount
- **Router guard fixes**: `beforeEach` now correctly awaits `isAuthenticated` and returns route objects instead of calling `router.push()` (prevents double-navigation); watcher in `useAuthLoad` is stopped on unmount to prevent stale callbacks
- **Payment confirmation rework**: Abonement purchases now show the digital-ring icon, a "View your subscription" button linked to the new `AbonementUrl` setting, and no longer incorrectly show the digital-download button
- **`AbonementUrl` setting**: Added to `Settings` interface, API form, and the General Settings admin panel

## Test plan

- [ ] Browse backoffice → Customers: list loads, create/edit/delete work
- [ ] Purchase an abonement in the shop and verify confirmation page shows ring icon and subscription link
- [ ] Navigate back from payment page and confirm no "Missing required param id" router error
- [ ] Open a protected backoffice view immediately after a hard reload and confirm data loads (auth race condition)
- [ ] Verify `AbonementUrl` can be set in General Settings and the link appears on the confirmation page