### PR TITLE
Add product ID column and CSV export

### DIFF
--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -63,14 +63,15 @@ defineExpose({ saveSettings })
 
 <template>
   <div class="space-y-6">
-
     <!-- Branding -->
     <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-5">
       <h2 class="text-base font-semibold text-gray-800 mb-4">{{ $t('Branding') }}</h2>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <!-- Newspaper name -->
         <div class="md:col-span-2">
-          <label class="block text-sm font-medium text-gray-700 mb-1">{{ $t('Newspaper name') }}</label>
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{
+            $t('Newspaper name')
+          }}</label>
           <input
             v-model="localSettings.NewspaperName"
             type="text"
@@ -81,36 +82,64 @@ defineExpose({ saveSettings })
         <!-- Color -->
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">{{ $t('color') }}</label>
-          <input v-model="localSettings.Color" type="text" class="w-full border rounded px-3 py-2 text-gray-700" required />
+          <input
+            v-model="localSettings.Color"
+            type="text"
+            class="w-full border rounded px-3 py-2 text-gray-700"
+            required
+          />
         </div>
         <!-- Font color -->
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">{{ $t('fontColor') }}</label>
-          <input v-model="localSettings.FontColor" type="text" class="w-full border rounded px-3 py-2 text-gray-700" required />
+          <input
+            v-model="localSettings.FontColor"
+            type="text"
+            class="w-full border rounded px-3 py-2 text-gray-700"
+            required
+          />
         </div>
         <!-- Logo -->
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">Logo</label>
           <img
             v-if="typeof localSettings.Logo === 'string' || !localSettings.Logo"
-            :src="localSettings.Logo ? props.url.replace(/\/$/, '') + localSettings.Logo : props.url + 'img/logo.png'"
+            :src="
+              localSettings.Logo
+                ? props.url.replace(/\/$/, '') + localSettings.Logo
+                : props.url + 'img/logo.png'
+            "
             alt="Logo"
             class="mb-2 h-16 object-contain"
           />
           <img v-else :src="newLogo" alt="Logo preview" class="mb-2 h-16 object-contain" />
-          <input type="file" accept="image/png" class="w-full border rounded px-3 py-1 text-sm text-gray-700" @change="updateLogo" />
+          <input
+            type="file"
+            accept="image/png"
+            class="w-full border rounded px-3 py-1 text-sm text-gray-700"
+            @change="updateLogo"
+          />
         </div>
         <!-- Favicon -->
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">Favicon</label>
           <img
             v-if="typeof localSettings.Favicon === 'string' || !localSettings.Favicon"
-            :src="localSettings.Favicon ? props.url + localSettings.Favicon.slice(1) : props.url + 'img/favicon.png'"
+            :src="
+              localSettings.Favicon
+                ? props.url + localSettings.Favicon.slice(1)
+                : props.url + 'img/favicon.png'
+            "
             alt="Favicon"
             class="mb-2 h-16 object-contain"
           />
           <img v-else :src="newFavicon" alt="Favicon preview" class="mb-2 h-16 object-contain" />
-          <input type="file" accept="image/png" class="w-full border rounded px-3 py-1 text-sm text-gray-700" @change="updateFavicon" />
+          <input
+            type="file"
+            accept="image/png"
+            class="w-full border rounded px-3 py-1 text-sm text-gray-700"
+            @change="updateFavicon"
+          />
         </div>
       </div>
     </div>
@@ -120,14 +149,28 @@ defineExpose({ saveSettings })
       <h2 class="text-base font-semibold text-gray-800 mb-4">{{ $t('Webshop') }}</h2>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{{ $t('mainProduct') }}</label>
-          <select v-model="localSettings.MainItem" class="w-full border rounded px-3 py-2 text-gray-700" required>
-            <option v-for="item in props.items" :key="item.ID" :value="item.ID">{{ item.Name }}</option>
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{
+            $t('mainProduct')
+          }}</label>
+          <select
+            v-model="localSettings.MainItem"
+            class="w-full border rounded px-3 py-2 text-gray-700"
+            required
+          >
+            <option v-for="item in props.items" :key="item.ID" :value="item.ID">
+              {{ item.Name }}
+            </option>
           </select>
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{{ $t('Max order amount') }}</label>
-          <input v-model.number="localSettings.MaxOrderAmount" type="number" class="w-full border rounded px-3 py-2 text-gray-700" />
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{
+            $t('Max order amount')
+          }}</label>
+          <input
+            v-model.number="localSettings.MaxOrderAmount"
+            type="number"
+            class="w-full border rounded px-3 py-2 text-gray-700"
+          />
         </div>
       </div>
       <div class="mt-4 grid grid-cols-2 md:grid-cols-3 gap-y-3 gap-x-4">
@@ -170,25 +213,59 @@ defineExpose({ saveSettings })
         <div>
           <label class="block text-sm font-medium text-gray-700 mb-1">{{ $t('AGB URL') }}</label>
           <div class="flex gap-2">
-            <input v-model="localSettings.AGBUrl" type="text" class="flex-1 border rounded px-3 py-2 text-gray-700" />
-            <button type="button" class="px-3 rounded bg-gray-100 border text-sm" @click="settingsStore.toAGB()">{{ $t('Open') }}</button>
+            <input
+              v-model="localSettings.AGBUrl"
+              type="text"
+              class="flex-1 border rounded px-3 py-2 text-gray-700"
+            />
+            <button
+              type="button"
+              class="px-3 rounded bg-gray-100 border text-sm"
+              @click="settingsStore.toAGB()"
+            >
+              {{ $t('Open') }}
+            </button>
           </div>
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{{ $t('Maintainance mode help URL') }}</label>
-          <input v-model="localSettings.MaintainanceModeHelpUrl" type="text" class="w-full border rounded px-3 py-2 text-gray-700" />
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{
+            $t('Maintainance mode help URL')
+          }}</label>
+          <input
+            v-model="localSettings.MaintainanceModeHelpUrl"
+            type="text"
+            class="w-full border rounded px-3 py-2 text-gray-700"
+          />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{{ $t('Vendor email postfix') }}</label>
-          <input v-model="localSettings.VendorEmailPostfix" type="text" class="w-full border rounded px-3 py-2 text-gray-700" />
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{
+            $t('Vendor email postfix')
+          }}</label>
+          <input
+            v-model="localSettings.VendorEmailPostfix"
+            type="text"
+            class="w-full border rounded px-3 py-2 text-gray-700"
+          />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{{ $t('Digital items URL') }}</label>
-          <input v-model="localSettings.DigitalItemsUrl" type="text" class="w-full border rounded px-3 py-2 text-gray-700" />
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{
+            $t('Digital items URL')
+          }}</label>
+          <input
+            v-model="localSettings.DigitalItemsUrl"
+            type="text"
+            class="w-full border rounded px-3 py-2 text-gray-700"
+          />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{{ $t('Abonement URL') }}</label>
-          <input v-model="localSettings.AbonementUrl" type="text" class="w-full border rounded px-3 py-2 text-gray-700" />
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{
+            $t('Abonement URL')
+          }}</label>
+          <input
+            v-model="localSettings.AbonementUrl"
+            type="text"
+            class="w-full border rounded px-3 py-2 text-gray-700"
+          />
         </div>
       </div>
     </div>
@@ -198,12 +275,26 @@ defineExpose({ saveSettings })
       <h2 class="text-base font-semibold text-gray-800 mb-4">{{ $t('menuMap') }}</h2>
       <div class="grid grid-cols-2 gap-4">
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{{ $t('Map center lat') }}</label>
-          <input v-model.number="localSettings.MapCenterLat" type="number" step="0.000001" class="w-full border rounded px-3 py-2 text-gray-700" />
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{
+            $t('Map center lat')
+          }}</label>
+          <input
+            v-model.number="localSettings.MapCenterLat"
+            type="number"
+            step="0.000001"
+            class="w-full border rounded px-3 py-2 text-gray-700"
+          />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{{ $t('Map center long') }}</label>
-          <input v-model.number="localSettings.MapCenterLong" type="number" step="0.000001" class="w-full border rounded px-3 py-2 text-gray-700" />
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{
+            $t('Map center long')
+          }}</label>
+          <input
+            v-model.number="localSettings.MapCenterLong"
+            type="number"
+            step="0.000001"
+            class="w-full border rounded px-3 py-2 text-gray-700"
+          />
         </div>
       </div>
     </div>
@@ -213,8 +304,15 @@ defineExpose({ saveSettings })
       <h2 class="text-base font-semibold text-gray-800 mb-4">{{ $t('QR-Code settings') }}</h2>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{{ $t('QR Code url') }}</label>
-          <input v-model="localSettings.QRCodeUrl" type="text" class="w-full border rounded px-3 py-2 text-gray-700" required />
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{
+            $t('QR Code url')
+          }}</label>
+          <input
+            v-model="localSettings.QRCodeUrl"
+            type="text"
+            class="w-full border rounded px-3 py-2 text-gray-700"
+            required
+          />
         </div>
         <div class="flex items-end">
           <label class="flex items-center gap-2 text-sm cursor-pointer">
@@ -223,15 +321,33 @@ defineExpose({ saveSettings })
           </label>
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{{ $t('QR Code logo') }}</label>
+          <label class="block text-sm font-medium text-gray-700 mb-1">{{
+            $t('QR Code logo')
+          }}</label>
           <img
-            v-if="typeof localSettings.QRCodeLogoImgUrl === 'string' || !localSettings.QRCodeLogoImgUrl"
-            :src="localSettings.QRCodeLogoImgUrl ? props.url + localSettings.QRCodeLogoImgUrl : props.url + 'img/qrcode.png'"
+            v-if="
+              typeof localSettings.QRCodeLogoImgUrl === 'string' || !localSettings.QRCodeLogoImgUrl
+            "
+            :src="
+              localSettings.QRCodeLogoImgUrl
+                ? props.url + localSettings.QRCodeLogoImgUrl
+                : props.url + 'img/qrcode.png'
+            "
             alt="QR code logo"
             class="mb-2 h-16 object-contain"
           />
-          <img v-else :src="newQrCodeLogo" alt="QR code logo preview" class="mb-2 h-16 object-contain" />
-          <input type="file" accept="image/png" class="w-full border rounded px-3 py-1 text-sm text-gray-700" @change="updateQRCodeLogo" />
+          <img
+            v-else
+            :src="newQrCodeLogo"
+            alt="QR code logo preview"
+            class="mb-2 h-16 object-contain"
+          />
+          <input
+            type="file"
+            accept="image/png"
+            class="w-full border rounded px-3 py-1 text-sm text-gray-700"
+            @change="updateQRCodeLogo"
+          />
         </div>
       </div>
     </div>
@@ -246,6 +362,5 @@ defineExpose({ saveSettings })
         {{ $t('save') }}
       </button>
     </div>
-
   </div>
 </template>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -348,5 +348,6 @@
   "posItemTotals": "Artikel gesamt",
   "downloadCSV": "CSV herunterladen",
   "Branding": "Markenauftritt",
-  "Webshop": "Webshop"
+  "Webshop": "Webshop",
+  "productId": "ID"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -259,5 +259,6 @@
   "posItemTotals": "Item totals",
   "downloadCSV": "Download CSV",
   "Branding": "Branding",
-  "Webshop": "Webshop"
+  "Webshop": "Webshop",
+  "productId": "ID"
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -473,11 +473,11 @@ async function isAuthenticated(to: RouteLocationNormalized) {
       keycloakStore.setUsername(keycloak.keycloak.tokenParsed.preferred_username)
     }
 
-    if (keycloak.keycloak?.tokenParsed?.groups.includes('vendor')) {
+    if (keycloak.keycloak?.tokenParsed?.groups?.includes('vendor')) {
       if (!to.path.startsWith('/me')) {
         return { name: 'My Info' }
       }
-    } else if (keycloak.keycloak?.tokenParsed?.groups.includes('backoffice')) {
+    } else if (keycloak.keycloak?.tokenParsed?.groups?.includes('backoffice')) {
       if (to.path.startsWith('/me')) {
         return { name: 'Backoffice' }
       }

--- a/src/views/backoffice/BackofficePOS.vue
+++ b/src/views/backoffice/BackofficePOS.vue
@@ -15,9 +15,8 @@ const vendorStore = vendorsStore()
 const itemsStore = useItemsStore()
 const settingsStore = useSettingsStore()
 
-const vendor = computed(() =>
-  (vendorStore.vendors ?? []).find((v) => v.LicenseID === licenseId)
-)
+const vendor = computed(() => (vendorStore.vendors ?? []).find((v) => v.LicenseID === licenseId))
+
 const posEnabled = computed(() => settingsStore.settings.POSEnabled)
 
 // qty map: itemId -> quantity
@@ -42,7 +41,10 @@ interface POSOrder {
 const posOrders = ref<POSOrder[]>([])
 const historyPage = ref(1)
 const historyPageSize = 10
-const historyTotalPages = computed(() => Math.max(1, Math.ceil(posOrders.value.length / historyPageSize)))
+const historyTotalPages = computed(() =>
+  Math.max(1, Math.ceil(posOrders.value.length / historyPageSize))
+)
+
 const pagedOrders = computed(() => {
   const start = (historyPage.value - 1) * historyPageSize
   return posOrders.value.slice(start, start + historyPageSize)
@@ -63,7 +65,7 @@ useAuthLoad(async () => {
     vendorStore.getVendors(),
     itemsStore.getItemsBackoffice(),
     settingsStore.getSettingsFromApi(),
-    loadPOSOrders(),
+    loadPOSOrders()
   ])
 
   // default qty 10 for issues
@@ -100,6 +102,7 @@ const balancePortion = computed(() => {
   if (!useBalance.value || vendorBalance.value <= 0) return 0
   return Math.min(vendorBalance.value, total.value)
 })
+
 const cashPortion = computed(() => total.value - balancePortion.value)
 
 function formatCents(cents: number) {
@@ -109,6 +112,7 @@ function formatCents(cents: number) {
 function inc(id: number) {
   quantities.value[id] = (quantities.value[id] ?? 0) + 1
 }
+
 function dec(id: number) {
   const current = quantities.value[id] ?? 0
   if (current > 0) quantities.value[id] = current - 1
@@ -128,6 +132,7 @@ async function completeSale() {
 
   submitting.value = true
   saleError.value = ''
+
   try {
     await postPOSOrder(licenseId, entries, useBalance.value)
     saleSuccess.value = true
@@ -142,6 +147,7 @@ async function completeSale() {
 function newSale() {
   saleSuccess.value = false
   saleError.value = ''
+
   for (const item of posItems.value) {
     quantities.value[item.ID] = item.Type === 'issue' ? 10 : 0
   }
@@ -154,6 +160,7 @@ const addingComment = ref(false)
 async function addComment() {
   if (!newComment.value.trim() || !vendor.value) return
   addingComment.value = true
+
   try {
     await vendorStore.createVendorComment({ comment: newComment.value } as any, vendor.value.ID)
     newComment.value = ''
@@ -167,248 +174,287 @@ const commentsOpen = ref(true)
 
 function formatDate(ts: string) {
   const d = new Date(ts)
-  return d.toLocaleDateString('de-AT') + ' ' + d.toLocaleTimeString('de-AT', { hour: '2-digit', minute: '2-digit' })
+  return (
+    d.toLocaleDateString('de-AT') +
+    ' ' +
+    d.toLocaleTimeString('de-AT', { hour: '2-digit', minute: '2-digit' })
+  )
 }
 </script>
 
 <template>
   <component :is="$route.meta.layout || 'div'">
-  <template #header>
-    <div class="flex items-center gap-4 p-4">
-      <button class="text-gray-500 hover:underline text-sm" @click="router.back()">← Back</button>
-      <h1 class="text-2xl font-bold">{{ $t('posTitle') }}</h1>
-    </div>
-  </template>
+    <template #header>
+      <div class="flex items-center gap-4 p-4">
+        <button class="text-gray-500 hover:underline text-sm" @click="router.back()">← Back</button>
+        <h1 class="text-2xl font-bold">{{ $t('posTitle') }}</h1>
+      </div>
+    </template>
 
-  <template #main>
-    <div class="p-4 flex gap-6 items-start">
-
-      <!-- Left column: POS form -->
-      <div class="flex-1 min-w-0 max-w-xl">
-        <!-- POS disabled banner -->
-        <div
-          v-if="!posEnabled"
-          class="mb-4 rounded bg-yellow-100 border border-yellow-400 text-yellow-800 px-4 py-3"
-        >
-          {{ $t('posDisabled') }}
-        </div>
-
-        <!-- Vendor header -->
-        <div v-if="vendor" class="mb-6 p-4 bg-white rounded shadow-sm flex justify-between items-start">
-          <div>
-            <div class="text-lg font-semibold">{{ vendor.FirstName }} {{ vendor.LastName }}</div>
-            <div class="text-sm text-gray-500">{{ vendor.LicenseID }}</div>
-            <div class="mt-1 text-sm">
-              {{ $t('posBalance') }}: <strong>{{ formatCents(vendorBalance) }}</strong>
-            </div>
-          </div>
-          <router-link :to="{ name: 'Update Vendor Profile', params: { ID: vendor.ID } }">
-            <button class="text-sm px-3 py-1 rounded border border-gray-300 hover:bg-gray-50 text-gray-600">
-              {{ $t('editVendor') }}
-            </button>
-          </router-link>
-        </div>
-
-        <!-- Success state -->
-        <div v-if="saleSuccess" class="p-6 bg-green-50 border border-green-300 rounded text-center">
-          <div class="text-xl font-bold text-green-700 mb-2">{{ $t('posSaleConfirmed') }}</div>
-          <div class="text-sm text-gray-600 mb-4">
-            <span v-if="balancePortion > 0">{{ formatCents(balancePortion) }} {{ $t('posFromBalance') }} + </span>
-            <span>{{ formatCents(cashPortion) }} {{ $t('posPayCash') }}</span>
-          </div>
-          <button
-            class="px-6 py-2 rounded bg-blue-600 text-white font-semibold hover:bg-blue-700"
-            @click="newSale"
+    <template #main>
+      <div class="p-4 flex gap-6 items-start">
+        <!-- Left column: POS form -->
+        <div class="flex-1 min-w-0 max-w-xl">
+          <!-- POS disabled banner -->
+          <div
+            v-if="!posEnabled"
+            class="mb-4 rounded bg-yellow-100 border border-yellow-400 text-yellow-800 px-4 py-3"
           >
-            {{ $t('posNewSale') }}
-          </button>
-        </div>
-
-        <template v-else>
-          <!-- Item grid -->
-          <div v-if="posItems.length === 0" class="mb-6 text-sm text-gray-500 italic">
-            {{ $t('posNoItems') }}
+            {{ $t('posDisabled') }}
           </div>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-6">
-            <div
-              v-for="item in posItems"
-              :key="item.ID"
-              class="flex items-center justify-between bg-white rounded shadow-sm p-3"
-            >
-              <div>
-                <div class="font-medium">{{ item.Name }}</div>
-                <div class="text-sm text-gray-500">{{ formatCents(item.Price) }}</div>
+
+          <!-- Vendor header -->
+          <div
+            v-if="vendor"
+            class="mb-6 p-4 bg-white rounded shadow-sm flex justify-between items-start"
+          >
+            <div>
+              <div class="text-lg font-semibold">{{ vendor.FirstName }} {{ vendor.LastName }}</div>
+              <div class="text-sm text-gray-500">{{ vendor.LicenseID }}</div>
+              <div class="mt-1 text-sm">
+                {{ $t('posBalance') }}: <strong>{{ formatCents(vendorBalance) }}</strong>
               </div>
-              <div class="flex items-center gap-2">
-                <button
-                  class="w-8 h-8 rounded bg-gray-200 font-bold text-lg leading-none"
-                  @click="dec(item.ID)"
-                >−</button>
+            </div>
+            <router-link :to="{ name: 'Update Vendor Profile', params: { ID: vendor.ID } }">
+              <button
+                class="text-sm px-3 py-1 rounded border border-gray-300 hover:bg-gray-50 text-gray-600"
+              >
+                {{ $t('editVendor') }}
+              </button>
+            </router-link>
+          </div>
+
+          <!-- Success state -->
+          <div
+            v-if="saleSuccess"
+            class="p-6 bg-green-50 border border-green-300 rounded text-center"
+          >
+            <div class="text-xl font-bold text-green-700 mb-2">{{ $t('posSaleConfirmed') }}</div>
+            <div class="text-sm text-gray-600 mb-4">
+              <span v-if="balancePortion > 0"
+                >{{ formatCents(balancePortion) }} {{ $t('posFromBalance') }} +
+              </span>
+              <span>{{ formatCents(cashPortion) }} {{ $t('posPayCash') }}</span>
+            </div>
+            <button
+              class="px-6 py-2 rounded bg-blue-600 text-white font-semibold hover:bg-blue-700"
+              @click="newSale"
+            >
+              {{ $t('posNewSale') }}
+            </button>
+          </div>
+
+          <template v-else>
+            <!-- Item grid -->
+            <div v-if="posItems.length === 0" class="mb-6 text-sm text-gray-500 italic">
+              {{ $t('posNoItems') }}
+            </div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-6">
+              <div
+                v-for="item in posItems"
+                :key="item.ID"
+                class="flex items-center justify-between bg-white rounded shadow-sm p-3"
+              >
+                <div>
+                  <div class="font-medium">{{ item.Name }}</div>
+                  <div class="text-sm text-gray-500">{{ formatCents(item.Price) }}</div>
+                </div>
+                <div class="flex items-center gap-2">
+                  <button
+                    class="w-8 h-8 rounded bg-gray-200 font-bold text-lg leading-none"
+                    @click="dec(item.ID)"
+                  >
+                    −
+                  </button>
+                  <input
+                    type="number"
+                    min="0"
+                    class="w-14 text-center font-semibold border rounded py-1"
+                    :value="quantities[item.ID] ?? 0"
+                    @change="
+                      quantities[item.ID] = Math.max(
+                        0,
+                        parseInt(($event.target as HTMLInputElement).value) || 0
+                      )
+                    "
+                  />
+                  <button
+                    class="w-8 h-8 rounded bg-gray-200 font-bold text-lg leading-none"
+                    @click="inc(item.ID)"
+                  >
+                    +
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <!-- Payment split -->
+            <div class="bg-white rounded shadow-sm p-4 mb-4">
+              <div class="flex justify-between text-lg font-semibold mb-3">
+                <span>{{ $t('posTotal') }}</span>
+                <span>{{ formatCents(total) }}</span>
+              </div>
+
+              <label v-if="vendorBalance > 0" class="flex items-center gap-2 mb-3 cursor-pointer">
+                <input v-model="useBalance" type="checkbox" />
+                <span class="text-sm">
+                  {{ $t('posUseBalance') }} ({{ formatCents(vendorBalance) }})
+                </span>
+              </label>
+
+              <div v-if="total > 0" class="text-sm text-gray-600 space-y-1">
+                <div v-if="balancePortion > 0" class="flex justify-between">
+                  <span>{{ $t('posFromBalance') }}</span>
+                  <span>{{ formatCents(balancePortion) }}</span>
+                </div>
+                <div class="flex justify-between">
+                  <span>{{ $t('posPayCash') }}</span>
+                  <span>{{ formatCents(cashPortion) }}</span>
+                </div>
+                <div v-if="balancePortion > 0" class="flex justify-between text-gray-400 mt-1">
+                  <span>{{ $t('posBalanceAfter') }}</span>
+                  <span>{{ formatCents(vendorBalance - balancePortion) }}</span>
+                </div>
+              </div>
+            </div>
+
+            <div v-if="saleError" class="mb-3 text-red-600 text-sm">{{ saleError }}</div>
+
+            <button
+              class="w-full py-3 rounded bg-blue-600 text-white font-bold text-lg hover:bg-blue-700 disabled:opacity-50"
+              :disabled="total === 0 || submitting || !posEnabled"
+              @click="completeSale"
+            >
+              {{ submitting ? '...' : $t('posCompleteSale') }}
+            </button>
+          </template>
+
+          <!-- Comments panel -->
+          <div class="mt-6 bg-white rounded shadow-sm">
+            <button
+              class="w-full flex justify-between items-center p-4 font-semibold"
+              @click="commentsOpen = !commentsOpen"
+            >
+              <span
+                >{{ $t('vendorComments') }} ({{ (vendorStore.vendorComments ?? []).length }})</span
+              >
+              <span>{{ commentsOpen ? '▲' : '▼' }}</span>
+            </button>
+            <div v-if="commentsOpen" class="px-4 pb-4">
+              <div
+                v-for="c in vendorStore.vendorComments ?? []"
+                :key="c.id"
+                class="border-b py-2 text-sm"
+              >
+                <span class="text-gray-400 text-xs mr-2">{{ c.id }}</span
+                >{{ c.comment }}
+              </div>
+              <div
+                v-if="!(vendorStore.vendorComments ?? []).length"
+                class="text-sm text-gray-400 py-2"
+              >
+                {{ $t('noComments') }}
+              </div>
+              <div class="flex gap-2 mt-3">
                 <input
-                  type="number"
-                  min="0"
-                  class="w-14 text-center font-semibold border rounded py-1"
-                  :value="quantities[item.ID] ?? 0"
-                  @change="quantities[item.ID] = Math.max(0, parseInt(($event.target as HTMLInputElement).value) || 0)"
+                  v-model="newComment"
+                  type="text"
+                  :placeholder="$t('addComment')"
+                  class="flex-1 border rounded px-3 py-1 text-sm"
+                  @keyup.enter="addComment"
                 />
                 <button
-                  class="w-8 h-8 rounded bg-gray-200 font-bold text-lg leading-none"
-                  @click="inc(item.ID)"
-                >+</button>
+                  class="px-3 py-1 rounded bg-gray-700 text-white text-sm hover:bg-gray-800 disabled:opacity-50"
+                  :disabled="addingComment || !newComment.trim()"
+                  @click="addComment"
+                >
+                  {{ $t('add') }}
+                </button>
               </div>
             </div>
           </div>
+        </div>
 
-          <!-- Payment split -->
-          <div class="bg-white rounded shadow-sm p-4 mb-4">
-            <div class="flex justify-between text-lg font-semibold mb-3">
-              <span>{{ $t('posTotal') }}</span>
-              <span>{{ formatCents(total) }}</span>
-            </div>
-
-            <label v-if="vendorBalance > 0" class="flex items-center gap-2 mb-3 cursor-pointer">
-              <input v-model="useBalance" type="checkbox" />
-              <span class="text-sm">
-                {{ $t('posUseBalance') }} ({{ formatCents(vendorBalance) }})
+        <!-- Right column: purchase history -->
+        <div class="w-80 shrink-0">
+          <div class="bg-white rounded shadow-sm">
+            <div class="p-4 border-b font-semibold text-gray-800 flex justify-between items-center">
+              <span>{{ $t('posHistory') }}</span>
+              <span v-if="posOrders.length > 0" class="text-xs font-normal text-gray-400">
+                {{ (historyPage - 1) * historyPageSize + 1 }}–{{
+                  Math.min(historyPage * historyPageSize, posOrders.length)
+                }}
+                / {{ posOrders.length }}
               </span>
-            </label>
-
-            <div v-if="total > 0" class="text-sm text-gray-600 space-y-1">
-              <div v-if="balancePortion > 0" class="flex justify-between">
-                <span>{{ $t('posFromBalance') }}</span>
-                <span>{{ formatCents(balancePortion) }}</span>
-              </div>
-              <div class="flex justify-between">
-                <span>{{ $t('posPayCash') }}</span>
-                <span>{{ formatCents(cashPortion) }}</span>
-              </div>
-              <div v-if="balancePortion > 0" class="flex justify-between text-gray-400 mt-1">
-                <span>{{ $t('posBalanceAfter') }}</span>
-                <span>{{ formatCents(vendorBalance - balancePortion) }}</span>
-              </div>
             </div>
-          </div>
-
-          <div v-if="saleError" class="mb-3 text-red-600 text-sm">{{ saleError }}</div>
-
-          <button
-            class="w-full py-3 rounded bg-blue-600 text-white font-bold text-lg hover:bg-blue-700 disabled:opacity-50"
-            :disabled="total === 0 || submitting || !posEnabled"
-            @click="completeSale"
-          >
-            {{ submitting ? '...' : $t('posCompleteSale') }}
-          </button>
-        </template>
-
-        <!-- Comments panel -->
-        <div class="mt-6 bg-white rounded shadow-sm">
-          <button
-            class="w-full flex justify-between items-center p-4 font-semibold"
-            @click="commentsOpen = !commentsOpen"
-          >
-            <span>{{ $t('vendorComments') }} ({{ (vendorStore.vendorComments ?? []).length }})</span>
-            <span>{{ commentsOpen ? '▲' : '▼' }}</span>
-          </button>
-          <div v-if="commentsOpen" class="px-4 pb-4">
+            <div v-if="posOrders.length === 0" class="p-4 text-sm text-gray-400 italic">
+              {{ $t('posNoHistory') }}
+            </div>
             <div
-              v-for="c in vendorStore.vendorComments ?? []"
-              :key="c.id"
-              class="border-b py-2 text-sm"
+              v-for="(order, idx) in pagedOrders"
+              :key="idx"
+              class="border-b last:border-0 px-4 py-3 space-y-2"
             >
-              <span class="text-gray-400 text-xs mr-2">{{ c.id }}</span>{{ c.comment }}
+              <!-- Date + total -->
+              <div class="flex justify-between items-center">
+                <span class="text-xs text-gray-400">{{ formatDate(order.timestamp) }}</span>
+                <span class="font-bold text-sm">{{
+                  formatCents(order.totalAmount || order.balanceUsed)
+                }}</span>
+              </div>
+              <!-- Item list -->
+              <ul v-if="order.items?.length" class="text-sm text-gray-700 space-y-0.5">
+                <li v-for="(item, i) in order.items" :key="i" class="flex justify-between">
+                  <span>{{ item.quantity }}× {{ item.itemName || `#${item.itemId}` }}</span>
+                  <span class="text-gray-400">{{ formatCents(item.amount) }}</span>
+                </li>
+              </ul>
+              <!-- Payment badges -->
+              <div class="flex gap-1 flex-wrap">
+                <span
+                  v-if="order.balanceUsed > 0"
+                  class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-blue-100 text-blue-700 font-medium"
+                >
+                  {{ $t('posBalanceUsed') }} {{ formatCents(order.balanceUsed) }}
+                </span>
+                <span
+                  v-if="order.cashAmount > 0"
+                  class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-green-100 text-green-700 font-medium"
+                >
+                  {{ $t('posCash') }} {{ formatCents(order.cashAmount) }}
+                </span>
+                <span
+                  v-if="!order.balanceUsed && !order.cashAmount && order.totalAmount"
+                  class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-green-100 text-green-700 font-medium"
+                >
+                  {{ $t('posCash') }} {{ formatCents(order.totalAmount) }}
+                </span>
+              </div>
             </div>
-            <div v-if="!(vendorStore.vendorComments ?? []).length" class="text-sm text-gray-400 py-2">
-              {{ $t('noComments') }}
-            </div>
-            <div class="flex gap-2 mt-3">
-              <input
-                v-model="newComment"
-                type="text"
-                :placeholder="$t('addComment')"
-                class="flex-1 border rounded px-3 py-1 text-sm"
-                @keyup.enter="addComment"
-              />
+            <!-- Pagination -->
+            <div
+              v-if="historyTotalPages > 1"
+              class="flex justify-between items-center px-4 py-2 border-t text-sm"
+            >
               <button
-                class="px-3 py-1 rounded bg-gray-700 text-white text-sm hover:bg-gray-800 disabled:opacity-50"
-                :disabled="addingComment || !newComment.trim()"
-                @click="addComment"
+                class="px-2 py-1 rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-50"
+                :disabled="historyPage === 1"
+                @click="historyPage--"
               >
-                {{ $t('add') }}
+                ‹
+              </button>
+              <span class="text-gray-500">{{ historyPage }} / {{ historyTotalPages }}</span>
+              <button
+                class="px-2 py-1 rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-50"
+                :disabled="historyPage === historyTotalPages"
+                @click="historyPage++"
+              >
+                ›
               </button>
             </div>
           </div>
         </div>
       </div>
-
-      <!-- Right column: purchase history -->
-      <div class="w-80 shrink-0">
-        <div class="bg-white rounded shadow-sm">
-          <div class="p-4 border-b font-semibold text-gray-800 flex justify-between items-center">
-            <span>{{ $t('posHistory') }}</span>
-            <span v-if="posOrders.length > 0" class="text-xs font-normal text-gray-400">
-              {{ (historyPage - 1) * historyPageSize + 1 }}–{{ Math.min(historyPage * historyPageSize, posOrders.length) }} / {{ posOrders.length }}
-            </span>
-          </div>
-          <div v-if="posOrders.length === 0" class="p-4 text-sm text-gray-400 italic">
-            {{ $t('posNoHistory') }}
-          </div>
-          <div
-            v-for="(order, idx) in pagedOrders"
-            :key="idx"
-            class="border-b last:border-0 px-4 py-3 space-y-2"
-          >
-            <!-- Date + total -->
-            <div class="flex justify-between items-center">
-              <span class="text-xs text-gray-400">{{ formatDate(order.timestamp) }}</span>
-              <span class="font-bold text-sm">{{ formatCents(order.totalAmount || order.balanceUsed) }}</span>
-            </div>
-            <!-- Item list -->
-            <ul v-if="order.items?.length" class="text-sm text-gray-700 space-y-0.5">
-              <li v-for="(item, i) in order.items" :key="i" class="flex justify-between">
-                <span>{{ item.quantity }}× {{ item.itemName || `#${item.itemId}` }}</span>
-                <span class="text-gray-400">{{ formatCents(item.amount) }}</span>
-              </li>
-            </ul>
-            <!-- Payment badges -->
-            <div class="flex gap-1 flex-wrap">
-              <span
-                v-if="order.balanceUsed > 0"
-                class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-blue-100 text-blue-700 font-medium"
-              >
-                {{ $t('posBalanceUsed') }} {{ formatCents(order.balanceUsed) }}
-              </span>
-              <span
-                v-if="order.cashAmount > 0"
-                class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-green-100 text-green-700 font-medium"
-              >
-                {{ $t('posCash') }} {{ formatCents(order.cashAmount) }}
-              </span>
-              <span
-                v-if="!order.balanceUsed && !order.cashAmount && order.totalAmount"
-                class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-green-100 text-green-700 font-medium"
-              >
-                {{ $t('posCash') }} {{ formatCents(order.totalAmount) }}
-              </span>
-            </div>
-          </div>
-          <!-- Pagination -->
-          <div v-if="historyTotalPages > 1" class="flex justify-between items-center px-4 py-2 border-t text-sm">
-            <button
-              class="px-2 py-1 rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-50"
-              :disabled="historyPage === 1"
-              @click="historyPage--"
-            >‹</button>
-            <span class="text-gray-500">{{ historyPage }} / {{ historyTotalPages }}</span>
-            <button
-              class="px-2 py-1 rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-50"
-              :disabled="historyPage === historyTotalPages"
-              @click="historyPage++"
-            >›</button>
-          </div>
-        </div>
-      </div>
-
-    </div>
-  </template>
+    </template>
   </component>
 </template>

--- a/src/views/backoffice/BackofficePOSAccounting.vue
+++ b/src/views/backoffice/BackofficePOSAccounting.vue
@@ -41,6 +41,7 @@ const loading = ref(false)
 
 async function load() {
   loading.value = true
+
   try {
     const res = await fetchAllPOSOrders(startDate.value, endDate.value)
     orders.value = res.data ?? []
@@ -53,6 +54,7 @@ const onRangeStart = (value: Date) => {
   startDate.value = value
   load()
 }
+
 const onRangeEnd = (value: Date) => {
   endDate.value = value
   load()
@@ -61,17 +63,23 @@ const onRangeEnd = (value: Date) => {
 useAuthLoad(load)
 
 const totalBalance = computed(() => orders.value.reduce((s, o) => s + o.balanceUsed, 0))
-const totalCash = computed(() => orders.value.reduce((s, o) => s + (o.cashAmount || (!o.balanceUsed ? o.totalAmount : 0)), 0))
-const totalAll = computed(() => orders.value.reduce((s, o) => s + (o.totalAmount || o.balanceUsed), 0))
+const totalCash = computed(() =>
+  orders.value.reduce((s, o) => s + (o.cashAmount || (!o.balanceUsed ? o.totalAmount : 0)), 0)
+)
+const totalAll = computed(() =>
+  orders.value.reduce((s, o) => s + (o.totalAmount || o.balanceUsed), 0)
+)
 const totalOrders = computed(() => orders.value.length)
 
 // Aggregate per-item totals across all orders
 const itemTotals = computed(() => {
   const map = new Map<string, { name: string; quantity: number; amount: number }>()
+
   for (const order of orders.value) {
     for (const item of order.items ?? []) {
       const key = item.itemName || `#${item.itemId}`
       const existing = map.get(key)
+
       if (existing) {
         existing.quantity += item.quantity
         existing.amount += item.amount
@@ -80,42 +88,49 @@ const itemTotals = computed(() => {
       }
     }
   }
+
   return [...map.values()].sort((a, b) => b.amount - a.amount)
 })
 
 function formatDate(ts: string) {
   const d = new Date(ts)
-  return d.toLocaleDateString('de-AT') + ' ' + d.toLocaleTimeString('de-AT', { hour: '2-digit', minute: '2-digit' })
+  return (
+    d.toLocaleDateString('de-AT') +
+    ' ' +
+    d.toLocaleTimeString('de-AT', { hour: '2-digit', minute: '2-digit' })
+  )
 }
 
 function itemSummary(order: POSOrder) {
   if (!order.items?.length) return '—'
-  return order.items.map(i => `${i.quantity}× ${i.itemName || '#' + i.itemId}`).join(', ')
+  return order.items.map((i) => `${i.quantity}× ${i.itemName || '#' + i.itemId}`).join(', ')
 }
 
 function downloadCSV() {
   const header = ['Datum', 'Verkäufer:in', 'Artikel', 'Guthaben (€)', 'Bar (€)', 'Gesamt (€)']
-  const rows = orders.value.map(o => [
+
+  const rows = orders.value.map((o) => [
     formatDate(o.timestamp),
     `${o.vendorName} (${o.vendorLicenseId})`,
     itemSummary(o),
     o.balanceUsed > 0 ? (o.balanceUsed / 100).toFixed(2) : '',
-    (o.cashAmount > 0 ? o.cashAmount : (!o.balanceUsed ? o.totalAmount : 0)) > 0
+    (o.cashAmount > 0 ? o.cashAmount : !o.balanceUsed ? o.totalAmount : 0) > 0
       ? ((o.cashAmount || o.totalAmount) / 100).toFixed(2)
       : '',
-    ((o.totalAmount || o.balanceUsed) / 100).toFixed(2),
+    ((o.totalAmount || o.balanceUsed) / 100).toFixed(2)
   ])
+
   rows.push([
     'Gesamt',
     '',
     '',
     (totalBalance.value / 100).toFixed(2),
     (totalCash.value / 100).toFixed(2),
-    (totalAll.value / 100).toFixed(2),
+    (totalAll.value / 100).toFixed(2)
   ])
 
   const csv = [header, ...rows]
-    .map(r => r.map(c => `"${String(c).replace(/"/g, '""')}"`).join(';'))
+    .map((r) => r.map((c) => `"${String(c).replace(/"/g, '""')}"`).join(';'))
     .join('\r\n')
 
   const blob = new Blob(['﻿' + csv], { type: 'text/csv;charset=utf-8;' })
@@ -158,7 +173,6 @@ function downloadCSV() {
 
     <template #main>
       <div class="main space-y-4">
-
         <!-- Summary cards -->
         <div v-if="orders.length > 0" class="grid grid-cols-2 sm:grid-cols-4 gap-3">
           <div class="bg-white rounded shadow-sm px-4 py-3">
@@ -213,7 +227,9 @@ function downloadCSV() {
                 <td colspan="6" class="p-4 text-center text-gray-400">…</td>
               </tr>
               <tr v-else-if="orders.length === 0">
-                <td colspan="6" class="p-4 text-center text-gray-400 italic">{{ $t('posNoHistory') }}</td>
+                <td colspan="6" class="p-4 text-center text-gray-400 italic">
+                  {{ $t('posNoHistory') }}
+                </td>
               </tr>
               <tr v-for="(order, idx) in orders" :key="idx" class="hover:bg-gray-50">
                 <td class="p-3 border-t whitespace-nowrap">{{ formatDate(order.timestamp) }}</td>
@@ -233,8 +249,12 @@ function downloadCSV() {
                   {{ order.balanceUsed > 0 ? formatCredit(order.balanceUsed) + ' €' : '—' }}
                 </td>
                 <td class="p-3 border-t text-right text-green-700">
-                  <template v-if="order.cashAmount > 0">{{ formatCredit(order.cashAmount) }} €</template>
-                  <template v-else-if="!order.balanceUsed && order.totalAmount">{{ formatCredit(order.totalAmount) }} €</template>
+                  <template v-if="order.cashAmount > 0"
+                    >{{ formatCredit(order.cashAmount) }} €</template
+                  >
+                  <template v-else-if="!order.balanceUsed && order.totalAmount"
+                    >{{ formatCredit(order.totalAmount) }} €</template
+                  >
                   <template v-else>—</template>
                 </td>
                 <td class="p-3 border-t text-right font-semibold">

--- a/src/views/backoffice/BackofficePOSPickVendor.vue
+++ b/src/views/backoffice/BackofficePOSPickVendor.vue
@@ -71,9 +71,21 @@ function initials(first: string, last: string) {
 
         <!-- Loading -->
         <div v-if="loading" class="flex justify-center py-16">
-          <svg class="animate-spin h-8 w-8 text-blue-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
+          <svg
+            class="animate-spin h-8 w-8 text-blue-500"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              class="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              stroke-width="4"
+            />
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
           </svg>
         </div>
 

--- a/src/views/backoffice/BackofficeProductSettings.vue
+++ b/src/views/backoffice/BackofficeProductSettings.vue
@@ -4,7 +4,9 @@ import { computed } from 'vue'
 import { formatCredit } from '@/utils/utils'
 import type { Item } from '@/stores/items'
 import { useAuthLoad } from '@/composables/useAuthLoad'
+import { useI18n } from 'vue-i18n'
 
+const { t } = useI18n()
 const itemsStore = useItemsStore()
 
 useAuthLoad(() => {
@@ -27,6 +29,43 @@ const items = computed(() => {
 })
 
 const apiUrl = import.meta.env.VITE_API_URL
+
+function exportCSV() {
+  const headers = [
+    t('productId'),
+    t('name'),
+    t('description'),
+    t('price'),
+    t('order'),
+    t('itemType'),
+    t('isDisabled')
+  ]
+
+  const rows = items.value.map((item: Item) => [
+    item.ID,
+    item.Name,
+    item.Description,
+    item.Price,
+    item.ItemOrder,
+    item.Type ?? '',
+    item.Disabled ? t('yes') : t('no')
+  ])
+
+  const csvContent = [headers, ...rows]
+    .map((row) =>
+      row.map((cell: unknown) => `"${String(cell ?? '').replace(/"/g, '""')}"`).join(',')
+    )
+    .join('\n')
+
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+
+  a.href = url
+  a.download = 'products.csv'
+  a.click()
+  URL.revokeObjectURL(url)
+}
 </script>
 
 <template>
@@ -37,10 +76,16 @@ const apiUrl = import.meta.env.VITE_API_URL
     <template #main>
       <div class="main w-full">
         <div class="mx-auto bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+          <div class="flex justify-end mb-4">
+            <button class="px-4 py-2 rounded-full customcolor h-[44px]" @click="exportCSV">
+              {{ $t('downloadCSV') }}
+            </button>
+          </div>
           <div className="text-xl space-y-3 space-x-3">
             <table className="table-auto w-full border-spacing-4 border-collapse">
               <thead>
                 <tr>
+                  <th class="p-3">{{ $t('productId') }}</th>
                   <th class="p-3">{{ $t('image') }}</th>
                   <th class="p-3">{{ $t('name') }}</th>
                   <th class="p-3">{{ $t('description') }}</th>
@@ -51,6 +96,7 @@ const apiUrl = import.meta.env.VITE_API_URL
               </thead>
               <tbody className="text-sm p-3">
                 <tr v-for="item in items" :key="item.ID" :class="{ 'disabled-row': item.Disabled }">
+                  <td class="border-t-2 p-3 text-gray-500">{{ item.ID }}</td>
                   <td class="border-t-2 p-3">
                     <img
                       :src="item.Image ? apiUrl + item.Image : ''"

--- a/src/views/backoffice/BackofficeProductUpdate.vue
+++ b/src/views/backoffice/BackofficeProductUpdate.vue
@@ -146,6 +146,15 @@ const previewImage = (image: string | Blob | MediaSource) => {
             </h2>
             <div class="space-y-4">
               <div>
+                <label class="field-label">{{ $t('productId') }}</label>
+                <input
+                  type="text"
+                  :value="updatedItem.ID"
+                  class="field-input bg-gray-100 text-gray-500"
+                  readonly
+                />
+              </div>
+              <div>
                 <label class="field-label" for="itemType">{{ $t('itemType') }}</label>
                 <select id="itemType" v-model="updatedItem.Type" class="field-input">
                   <option v-for="t in ITEM_TYPES" :key="t" :value="t">

--- a/src/views/backoffice/SettingsUpdate.vue
+++ b/src/views/backoffice/SettingsUpdate.vue
@@ -108,21 +108,45 @@ const currentTab = ref<'general' | 'styles' | 'qrcode' | 'mailtemplates'>('gener
         <!-- Tab nav -->
         <div class="mb-6 flex gap-2 border-b pb-2">
           <button
-            :class="currentTab === 'general' ? 'px-4 py-2 bg-black text-white rounded-t' : 'px-4 py-2 border rounded-t'"
+            :class="
+              currentTab === 'general'
+                ? 'px-4 py-2 bg-black text-white rounded-t'
+                : 'px-4 py-2 border rounded-t'
+            "
             @click="currentTab = 'general'"
-          >{{ $t('General') }}</button>
+          >
+            {{ $t('General') }}
+          </button>
           <button
-            :class="currentTab === 'styles' ? 'px-4 py-2 bg-black text-white rounded-t' : 'px-4 py-2 border rounded-t'"
+            :class="
+              currentTab === 'styles'
+                ? 'px-4 py-2 bg-black text-white rounded-t'
+                : 'px-4 py-2 border rounded-t'
+            "
             @click="currentTab = 'styles'"
-          >{{ $t('Custom styles') }}</button>
+          >
+            {{ $t('Custom styles') }}
+          </button>
           <button
-            :class="currentTab === 'qrcode' ? 'px-4 py-2 bg-black text-white rounded-t' : 'px-4 py-2 border rounded-t'"
+            :class="
+              currentTab === 'qrcode'
+                ? 'px-4 py-2 bg-black text-white rounded-t'
+                : 'px-4 py-2 border rounded-t'
+            "
             @click="currentTab = 'qrcode'"
-          >{{ $t('QR-Code settings') }}</button>
+          >
+            {{ $t('QR-Code settings') }}
+          </button>
           <button
-            :class="currentTab === 'mailtemplates' ? 'px-4 py-2 bg-black text-white rounded-t' : 'px-4 py-2 border rounded-t'"
+            :class="
+              currentTab === 'mailtemplates'
+                ? 'px-4 py-2 bg-black text-white rounded-t'
+                : 'px-4 py-2 border rounded-t'
+            "
             @click="currentTab = 'mailtemplates'"
-          >{{ $t('Mail Templates') }}</button>
+          >
+            {{ $t('Mail Templates') }}
+          </button>
         </div>
 
         <GeneralSettings


### PR DESCRIPTION
## Summary

- Show product ID as the first column on the backoffice product overview table
- Add a "CSV herunterladen" button above the table to download all products as a CSV file (columns: ID, name, description, price, order, type, disabled)
- Show a read-only ID field at the top of the product update form
- Add `productId` i18n key to `de.json` and `en.json`

## Test plan

- [ ] Open backoffice product overview — verify ID column appears as first column
- [ ] Click "CSV herunterladen" — verify `products.csv` downloads with correct headers and one row per product
- [ ] Open a product for editing — verify a grey read-only "ID" field appears at the top of the basic info section