### PR TITLE
Hide POS and customers nav items when feature is disabled

### DIFF
--- a/src/layouts/BackofficeLayout.vue
+++ b/src/layouts/BackofficeLayout.vue
@@ -81,7 +81,7 @@ onMounted(() => {
                 <img :src="logo" alt="Newspaper logo" class="logo mx-auto" width="auto" />
               </div>
               <div class="sidemenu-item flex flex-col w-full space-y-2">
-                <RouterLink to="/backoffice/customers">
+                <RouterLink v-if="settings.AbonementUrl" to="/backoffice/customers">
                   <button
                     class="flex justify-start w-full space-x-4 focus:outline-none customcolor focus:text-indigo-400 pr-5 pb-1 rounded"
                   >
@@ -97,7 +97,7 @@ onMounted(() => {
                     <p class="text-base leading-4">{{ $t('menuVendors') }}</p>
                   </button>
                 </RouterLink>
-                <RouterLink to="/backoffice/pos">
+                <RouterLink v-if="settings.POSEnabled" to="/backoffice/pos">
                   <button
                     class="flex justify-start w-full space-x-4 focus:outline-none customcolor focus:text-indigo-400 pr-5 pb-1 rounded"
                   >
@@ -113,7 +113,11 @@ onMounted(() => {
                     <p class="text-base leading-4">{{ $t('menuCredits') }}</p>
                   </button>
                 </RouterLink>
-                <RouterLink to="/backoffice/pos-accounting" class-name="sidemenu-link">
+                <RouterLink
+                  v-if="settings.POSEnabled"
+                  to="/backoffice/pos-accounting"
+                  class-name="sidemenu-link"
+                >
                   <button
                     class="flex justify-start items-center w-full space-x-5 focus:outline-none customcolor focus:text-indigo-400 pr-5 pb-1 rounded"
                   >

--- a/src/views/backoffice/BackofficePOSAccounting.vue
+++ b/src/views/backoffice/BackofficePOSAccounting.vue
@@ -63,12 +63,15 @@ const onRangeEnd = (value: Date) => {
 useAuthLoad(load)
 
 const totalBalance = computed(() => orders.value.reduce((s, o) => s + o.balanceUsed, 0))
+
 const totalCash = computed(() =>
   orders.value.reduce((s, o) => s + (o.cashAmount || (!o.balanceUsed ? o.totalAmount : 0)), 0)
 )
+
 const totalAll = computed(() =>
   orders.value.reduce((s, o) => s + (o.totalAmount || o.balanceUsed), 0)
 )
+
 const totalOrders = computed(() => orders.value.length)
 
 // Aggregate per-item totals across all orders
@@ -114,9 +117,12 @@ function downloadCSV() {
     `${o.vendorName} (${o.vendorLicenseId})`,
     itemSummary(o),
     o.balanceUsed > 0 ? (o.balanceUsed / 100).toFixed(2) : '',
-    (o.cashAmount > 0 ? o.cashAmount : !o.balanceUsed ? o.totalAmount : 0) > 0
-      ? ((o.cashAmount || o.totalAmount) / 100).toFixed(2)
-      : '',
+    (() => {
+      let effectiveCash = 0
+      if (o.cashAmount > 0) effectiveCash = o.cashAmount
+      else if (!o.balanceUsed) effectiveCash = o.totalAmount
+      return effectiveCash > 0 ? ((o.cashAmount || o.totalAmount) / 100).toFixed(2) : ''
+    })(),
     ((o.totalAmount || o.balanceUsed) / 100).toFixed(2)
   ])
 


### PR DESCRIPTION
## Summary

- POS and POS Accounting sidebar links are hidden when `settings.POSEnabled` is `false`
- Customers sidebar link is hidden when `settings.AbonementUrl` is empty (no abonement configured — there is no separate `AbonementEnabled` flag; the presence of an URL is the indicator)

## Test plan

- [ ] Disable POS in settings → verify "POS" and "POS Accounting" disappear from the sidebar
- [ ] Clear the Abonement URL in settings → verify "Customers" disappears from the sidebar
- [ ] Re-enable both → verify all links return