### PR TITLE
Fix double slash in Keycloak redirect URI causing site-not-found

### DIFF
--- a/src/components/settings/MailTemplatesSettings.vue
+++ b/src/components/settings/MailTemplatesSettings.vue
@@ -132,8 +132,10 @@ const insertVar = (v: string) => {
   mailStore.current.body = body.slice(0, start) + v + body.slice(end)
   const newPos = start + v.length
   savedCursor.value = { start: newPos, end: newPos }
+
   nextTick(() => {
     const el = textareaRef.value
+
     if (el) {
       el.focus()
       el.setSelectionRange(newPos, newPos)
@@ -156,17 +158,20 @@ const DEMO_VALUES: Record<string, string> = {
 
 function renderPreview(body: string): string {
   let s = body
+
   // {{if .X}}...{{else}}...{{end}}
   s = s.replace(
     /\{\{if \.(\w+)\}\}([\s\S]*?)\{\{else\}\}([\s\S]*?)\{\{end\}\}/g,
     (_, varName, ifBlock, elseBlock) =>
       DEMO_VALUES[varName] !== undefined ? ifBlock : elseBlock,
   )
+
   // {{if .X}}...{{end}} (no else)
   s = s.replace(
     /\{\{if \.(\w+)\}\}([\s\S]*?)\{\{end\}\}/g,
     (_, varName, block) => (DEMO_VALUES[varName] !== undefined ? block : ''),
   )
+
   // {{.X}}
   s = s.replace(/\{\{\.(\w+)\}\}/g, (_, varName) => DEMO_VALUES[varName] ?? `[${varName}]`)
   return s

--- a/src/keycloak/keycloak.ts
+++ b/src/keycloak/keycloak.ts
@@ -70,9 +70,12 @@ export const initKeycloak = async () => {
     if (!keycloak.keycloak) return
 
     if (!authenticated) {
+      const path = window.location.pathname.endsWith('/')
+        ? window.location.pathname
+        : window.location.pathname + '/'
       keycloak.keycloak.login({
         locale: 'de',
-        redirectUri: window.location.origin + window.location.pathname + '/'
+        redirectUri: window.location.origin + path
       })
     }
   }

--- a/src/keycloak/keycloak.ts
+++ b/src/keycloak/keycloak.ts
@@ -73,6 +73,7 @@ export const initKeycloak = async () => {
       const path = window.location.pathname.endsWith('/')
         ? window.location.pathname
         : window.location.pathname + '/'
+
       keycloak.keycloak.login({
         locale: 'de',
         redirectUri: window.location.origin + path

--- a/src/views/backoffice/BackofficePOSAccounting.vue
+++ b/src/views/backoffice/BackofficePOSAccounting.vue
@@ -63,12 +63,15 @@ const onRangeEnd = (value: Date) => {
 useAuthLoad(load)
 
 const totalBalance = computed(() => orders.value.reduce((s, o) => s + o.balanceUsed, 0))
+
 const totalCash = computed(() =>
   orders.value.reduce((s, o) => s + (o.cashAmount || (!o.balanceUsed ? o.totalAmount : 0)), 0)
 )
+
 const totalAll = computed(() =>
   orders.value.reduce((s, o) => s + (o.totalAmount || o.balanceUsed), 0)
 )
+
 const totalOrders = computed(() => orders.value.length)
 
 // Aggregate per-item totals across all orders

--- a/src/views/backoffice/BackofficeProductNew.vue
+++ b/src/views/backoffice/BackofficeProductNew.vue
@@ -12,6 +12,7 @@ const { t } = useI18n()
 
 const store = useItemsStore()
 const settingsStore = useSettingsStore()
+
 const availableItemTypes = computed(() =>
   ITEM_TYPES.filter((type) => type !== 'abonement' || settingsStore.settings.AbonementEnabled)
 )

--- a/src/views/backoffice/BackofficeProductUpdate.vue
+++ b/src/views/backoffice/BackofficeProductUpdate.vue
@@ -14,9 +14,11 @@ import { useRoute } from 'vue-router'
 const itemsStore = useItemsStore()
 const keycloakStore = useKeycloakStore()
 const settingsStore = useSettingsStore()
+
 const availableItemTypes = computed(() =>
   ITEM_TYPES.filter((type) => type !== 'abonement' || settingsStore.settings.AbonementEnabled)
 )
+
 const authenticated = computed(() => keycloakStore.authenticated)
 
 const updatedItem = ref<Item | null>()


### PR DESCRIPTION
## Problem

After logging in via Keycloak, users sometimes landed on a URL with a double slash (`https://host//…`) and got a **site-not-found** error.

## Cause

In [`src/keycloak/keycloak.ts`](src/keycloak/keycloak.ts), the login `redirectUri` was built as:

```ts
redirectUri: window.location.origin + window.location.pathname + '/'
```

`window.location.pathname` already ends in `/` on the root route (`"/"`) and on other trailing-slash routes, so appending another `'/'` produced a double slash. Keycloak reflects that `redirectUri` back verbatim after login, and `//` matches no route in the SPA router → site-not-found.

## Fix

Only append the trailing slash when it isn't already present:

```ts
const path = window.location.pathname.endsWith('/')
  ? window.location.pathname
  : window.location.pathname + '/'
keycloak.keycloak.login({
  locale: 'de',
  redirectUri: window.location.origin + path
})
```

## Note

The Keycloak client's **Valid Redirect URIs** should include the single-slash form (e.g. `https://yourdomain.com/*`), which it almost certainly already does via a wildcard.