### PR TITLE
Fix landing page hanging instead of redirecting to shop

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -178,11 +178,21 @@ export async function patchSettings(updatedSettings: Settings) {
   formData.append('NewspaperName', updatedSettings.NewspaperName ?? '')
   formData.append('MapCenterLat', (updatedSettings.MapCenterLat ?? 0).toString())
   formData.append('MapCenterLong', (updatedSettings.MapCenterLong ?? 0).toString())
-  formData.append('UseVendorLicenseIdInShop', (updatedSettings.UseVendorLicenseIdInShop ?? false).toString())
+
+  formData.append(
+    'UseVendorLicenseIdInShop',
+    (updatedSettings.UseVendorLicenseIdInShop ?? false).toString()
+  )
+
   formData.append('Favicon', updatedSettings.Favicon || '')
   formData.append('QRCodeSettings', updatedSettings.QRCodeSettings ?? '')
   formData.append('QRCodeEnableLogo', (updatedSettings.QRCodeEnableLogo ?? false).toString())
-  formData.append('UseTipInsteadOfDonation', (updatedSettings.UseTipInsteadOfDonation ?? false).toString())
+
+  formData.append(
+    'UseTipInsteadOfDonation',
+    (updatedSettings.UseTipInsteadOfDonation ?? false).toString()
+  )
+
   formData.append('ShopLanding', (updatedSettings.ShopLanding ?? false).toString())
   formData.append('DigitalItemsUrl', updatedSettings.DigitalItemsUrl ?? '')
   formData.append('AbonementUrl', updatedSettings.AbonementUrl ?? '')
@@ -191,7 +201,12 @@ export async function patchSettings(updatedSettings: Settings) {
   formData.append('WordPressInviteURL', updatedSettings.WordPressInviteURL ?? '')
   formData.append('WordPressInviteAPIKey', updatedSettings.WordPressInviteAPIKey ?? '')
   formData.append('WordPressInviteTTL', (updatedSettings.WordPressInviteTTL ?? 604800).toString())
-  formData.append('OrgaCoversTransactionCosts', (updatedSettings.OrgaCoversTransactionCosts ?? true).toString())
+
+  formData.append(
+    'OrgaCoversTransactionCosts',
+    (updatedSettings.OrgaCoversTransactionCosts ?? true).toString()
+  )
+
   formData.append('MaxOrderAmount', (updatedSettings.MaxOrderAmount ?? 0).toString())
 
   return apiInstance.put(`${SETTINGS_API_URL}`, formData, {

--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -287,10 +287,7 @@ defineExpose({ saveSettings })
         {{ $t('wpInviteTitle') }}
       </h2>
       <label class="flex items-center gap-2 text-sm cursor-pointer mb-4">
-        <input
-          v-model="wpInviteEnabled"
-          type="checkbox"
-        />
+        <input v-model="wpInviteEnabled" type="checkbox" />
         {{ $t('wpInviteEnabled') }}
       </label>
       <div v-if="wpInviteEnabled" class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -411,6 +408,5 @@ defineExpose({ saveSettings })
         </div>
       </div>
     </div>
-
   </div>
 </template>

--- a/src/components/settings/MailTemplatesSettings.vue
+++ b/src/components/settings/MailTemplatesSettings.vue
@@ -88,16 +88,16 @@ const bodyTab = ref<'edit' | 'preview'>('edit')
 const TEMPLATE_VARS: Record<string, { name: string; desc: string }[]> = {
   welcome: [
     { name: '{{.URL}}', desc: 'Link zur Online-Ausgabe' },
-    { name: '{{.EMAIL}}', desc: 'E-Mail-Adresse der Käuferin' },
+    { name: '{{.EMAIL}}', desc: 'E-Mail-Adresse der Käuferin' }
   ],
   'digitalLicenceItemTemplate.html': [
     { name: '{{.URL}}', desc: 'Link zur Online-Ausgabe' },
     { name: '{{.EMAIL}}', desc: 'E-Mail-Adresse der Käuferin' },
-    { name: '{{.InviteURL}}', desc: 'Einmaliger WordPress-Login-Link (optional)' },
+    { name: '{{.InviteURL}}', desc: 'Einmaliger WordPress-Login-Link (optional)' }
   ],
   'PDFLicenceItemTemplate.html': [
     { name: '{{.URL}}', desc: 'Download-Link zum PDF' },
-    { name: '{{.EMAIL}}', desc: 'E-Mail-Adresse der Käuferin' },
+    { name: '{{.EMAIL}}', desc: 'E-Mail-Adresse der Käuferin' }
   ],
   abonementConfirmation: [
     { name: '{{.CustomerName}}', desc: 'Vor- und Nachname der Kundin' },
@@ -105,12 +105,12 @@ const TEMPLATE_VARS: Record<string, { name: string; desc: string }[]> = {
     { name: '{{.FromDate}}', desc: 'Startdatum (YYYY-MM-DD)' },
     { name: '{{.ToDate}}', desc: 'Enddatum (YYYY-MM-DD)' },
     { name: '{{.Status}}', desc: 'Status des Abonnements' },
-    { name: '{{.InviteURL}}', desc: 'Einmaliger WordPress-Login-Link (optional)' },
+    { name: '{{.InviteURL}}', desc: 'Einmaliger WordPress-Login-Link (optional)' }
   ],
   onlineIssuePublished: [
     { name: '{{.IssueName}}', desc: 'Name der Ausgabe' },
-    { name: '{{.ImageURL}}', desc: 'URL zum Titelbild' },
-  ],
+    { name: '{{.ImageURL}}', desc: 'URL zum Titelbild' }
+  ]
 }
 
 const currentVars = computed(() =>
@@ -132,8 +132,10 @@ const insertVar = (v: string) => {
   mailStore.current.body = body.slice(0, start) + v + body.slice(end)
   const newPos = start + v.length
   savedCursor.value = { start: newPos, end: newPos }
+
   nextTick(() => {
     const el = textareaRef.value
+
     if (el) {
       el.focus()
       el.setSelectionRange(newPos, newPos)
@@ -151,29 +153,30 @@ const DEMO_VALUES: Record<string, string> = {
   ToDate: '2026-12-31',
   Status: 'active',
   IssueName: 'Augustin Ausgabe Juni 2026',
-  ImageURL: 'https://placehold.co/600x400?text=Augustin+Cover',
+  ImageURL: 'https://placehold.co/600x400?text=Augustin+Cover'
 }
 
 function renderPreview(body: string): string {
   let s = body
+
   // {{if .X}}...{{else}}...{{end}}
   s = s.replace(
     /\{\{if \.(\w+)\}\}([\s\S]*?)\{\{else\}\}([\s\S]*?)\{\{end\}\}/g,
-    (_, varName, ifBlock, elseBlock) =>
-      DEMO_VALUES[varName] !== undefined ? ifBlock : elseBlock,
+    (_, varName, ifBlock, elseBlock) => (DEMO_VALUES[varName] !== undefined ? ifBlock : elseBlock)
   )
+
   // {{if .X}}...{{end}} (no else)
-  s = s.replace(
-    /\{\{if \.(\w+)\}\}([\s\S]*?)\{\{end\}\}/g,
-    (_, varName, block) => (DEMO_VALUES[varName] !== undefined ? block : ''),
+  s = s.replace(/\{\{if \.(\w+)\}\}([\s\S]*?)\{\{end\}\}/g, (_, varName, block) =>
+    DEMO_VALUES[varName] !== undefined ? block : ''
   )
+
   // {{.X}}
   s = s.replace(/\{\{\.(\w+)\}\}/g, (_, varName) => DEMO_VALUES[varName] ?? `[${varName}]`)
   return s
 }
 
 const previewBody = computed(() =>
-  mailStore.current?.body ? renderPreview(mailStore.current.body) : '',
+  mailStore.current?.body ? renderPreview(mailStore.current.body) : ''
 )
 
 onMounted(() => {
@@ -210,7 +213,10 @@ onMounted(() => {
           <div v-if="mailStore.current && mailStore.current.name">
             <!-- Subject -->
             <label class="block text-sm font-medium text-gray-700 mb-1">{{ $t('Subject') }}</label>
-            <input v-model="mailStore.current.subject" class="w-full border rounded px-3 py-2 mb-4 text-gray-700" />
+            <input
+              v-model="mailStore.current.subject"
+              class="w-full border rounded px-3 py-2 mb-4 text-gray-700"
+            />
 
             <!-- Body with Edit/Preview tabs -->
             <div class="mb-1 flex items-center justify-between">
@@ -219,15 +225,27 @@ onMounted(() => {
                 <button
                   type="button"
                   class="px-3 py-1 text-xs rounded"
-                  :class="bodyTab === 'edit' ? 'bg-black text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
+                  :class="
+                    bodyTab === 'edit'
+                      ? 'bg-black text-white'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                  "
                   @click="bodyTab = 'edit'"
-                >{{ $t('edit') }}</button>
+                >
+                  {{ $t('edit') }}
+                </button>
                 <button
                   type="button"
                   class="px-3 py-1 text-xs rounded"
-                  :class="bodyTab === 'preview' ? 'bg-black text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'"
+                  :class="
+                    bodyTab === 'preview'
+                      ? 'bg-black text-white'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                  "
                   @click="bodyTab = 'preview'"
-                >{{ $t('preview') }}</button>
+                >
+                  {{ $t('preview') }}
+                </button>
               </div>
             </div>
             <textarea
@@ -247,8 +265,13 @@ onMounted(() => {
             ></iframe>
 
             <!-- Variable chips -->
-            <div v-if="currentVars.length" class="mb-4 p-3 bg-gray-50 rounded border border-gray-200">
-              <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">{{ $t('templateVars') }}</p>
+            <div
+              v-if="currentVars.length"
+              class="mb-4 p-3 bg-gray-50 rounded border border-gray-200"
+            >
+              <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">
+                {{ $t('templateVars') }}
+              </p>
               <div class="flex flex-wrap gap-2">
                 <button
                   v-for="v in currentVars"
@@ -265,7 +288,9 @@ onMounted(() => {
             </div>
 
             <!-- Test email -->
-            <label class="block text-sm font-medium text-gray-700 mb-1">{{ $t('Test email') }}</label>
+            <label class="block text-sm font-medium text-gray-700 mb-1">{{
+              $t('Test email')
+            }}</label>
             <div class="flex gap-2 mb-4">
               <input
                 v-model="testEmail"

--- a/src/layouts/BackofficeLayout.vue
+++ b/src/layouts/BackofficeLayout.vue
@@ -113,7 +113,11 @@ onMounted(() => {
                     <p class="text-base leading-4">{{ $t('menuCredits') }}</p>
                   </button>
                 </RouterLink>
-                <RouterLink v-if="settings.POSEnabled" to="/backoffice/pos-accounting" class-name="sidemenu-link">
+                <RouterLink
+                  v-if="settings.POSEnabled"
+                  to="/backoffice/pos-accounting"
+                  class-name="sidemenu-link"
+                >
                   <button
                     class="flex justify-start items-center w-full space-x-5 focus:outline-none customcolor focus:text-indigo-400 pr-5 pb-1 rounded"
                   >

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,6 +1,10 @@
 import { defineStore } from 'pinia'
 import { fetchSettings, patchSettings, patchSettingsStyles, getStyles } from '@/api/api'
 
+// Shared in-flight request so concurrent callers await the same fetch instead
+// of racing (or resolving before the settings are actually loaded).
+let inflightSettingsRequest: Promise<void> | null = null
+
 //define interface to store data from backend properly
 export interface Settings {
   ID: number
@@ -65,11 +69,19 @@ export const useSettingsStore = defineStore('settings', {
 
   actions: {
     async getSettingsFromApi() {
-      if (this.settingsLoaded || this.isLoading) {
+      if (this.settingsLoaded) {
         return
       }
 
-      fetchSettings()
+      // A load is already running: await the same request so callers only
+      // resolve once the settings are actually populated.
+      if (inflightSettingsRequest) {
+        return inflightSettingsRequest
+      }
+
+      this.isLoading = true
+
+      inflightSettingsRequest = fetchSettings()
         .then((data) => {
           this.settings = data.data.Settings
           this.settings.Keycloak = data.data.Keycloak
@@ -80,12 +92,17 @@ export const useSettingsStore = defineStore('settings', {
           this.settings.MainItemPrice = data.data.Settings.edges.MainItem.Price
           this.imgUrl = import.meta.env.VITE_API_URL + this.settings.Logo
           this.settingsLoaded = true
-          this.isLoading = false
         })
         .catch((error) => {
           // eslint-disable-next-line no-console
           console.log('failed to get the settings', error)
         })
+        .finally(() => {
+          this.isLoading = false
+          inflightSettingsRequest = null
+        })
+
+      return inflightSettingsRequest
     },
 
     toAGB() {

--- a/src/views/LandingPage.vue
+++ b/src/views/LandingPage.vue
@@ -26,11 +26,9 @@ onMounted(() => {
 
   settStore.getSettingsFromApi().then(() => {
     // ensure we have a vendor id (in case of direct reload); prefer store value but fall back to route param
-    if (!vendorStore.vendorid && route.params && route.params.vendorid) {
-      // route.params.vendorid may be string or array; normalize to string
-      const vid = Array.isArray(route.params.vendorid)
-        ? route.params.vendorid[0]
-        : route.params.vendorid
+    if (!vendorStore.vendorid && route.params && route.params.id) {
+      // route.params.id may be string or array; normalize to string
+      const vid = Array.isArray(route.params.id) ? route.params.id[0] : route.params.id
 
       if (vid) vendorStore.vendorid = String(vid)
 

--- a/src/views/PaymentConfirmation.vue
+++ b/src/views/PaymentConfirmation.vue
@@ -283,7 +283,11 @@ const email = localStorage.getItem('email') || ''
             </a>
           </div>
           <div
-            v-if="hasAbonementPurchase && settStore.settings.AbonementEnabled && settStore.settings.AbonementUrl"
+            v-if="
+              hasAbonementPurchase &&
+              settStore.settings.AbonementEnabled &&
+              settStore.settings.AbonementUrl
+            "
             class="abonement-link mt-3"
           >
             <a :href="settStore.settings.AbonementUrl" target="_blank" rel="noopener noreferrer">
@@ -300,10 +304,7 @@ const email = localStorage.getItem('email') || ''
               </button>
             </a>
           </div>
-          <div
-            v-if="paymentStore.verification?.InviteURL"
-            class="wp-invite-link mt-3"
-          >
+          <div v-if="paymentStore.verification?.InviteURL" class="wp-invite-link mt-3">
             <a
               :href="paymentStore.verification.InviteURL"
               target="_blank"

--- a/src/views/backoffice/BackofficePOSAccounting.vue
+++ b/src/views/backoffice/BackofficePOSAccounting.vue
@@ -63,12 +63,15 @@ const onRangeEnd = (value: Date) => {
 useAuthLoad(load)
 
 const totalBalance = computed(() => orders.value.reduce((s, o) => s + o.balanceUsed, 0))
+
 const totalCash = computed(() =>
   orders.value.reduce((s, o) => s + (o.cashAmount || (!o.balanceUsed ? o.totalAmount : 0)), 0)
 )
+
 const totalAll = computed(() =>
   orders.value.reduce((s, o) => s + (o.totalAmount || o.balanceUsed), 0)
 )
+
 const totalOrders = computed(() => orders.value.length)
 
 // Aggregate per-item totals across all orders
@@ -106,6 +109,14 @@ function itemSummary(order: POSOrder) {
   return order.items.map((i) => `${i.quantity}× ${i.itemName || '#' + i.itemId}`).join(', ')
 }
 
+// Cash paid for an order, in cents: explicit cash amount, otherwise the full
+// total when no balance was used, otherwise nothing.
+function cashPaid(o: POSOrder): number {
+  if (o.cashAmount > 0) return o.cashAmount
+  if (!o.balanceUsed) return o.totalAmount
+  return 0
+}
+
 function downloadCSV() {
   const header = ['Datum', 'Verkäufer:in', 'Artikel', 'Guthaben (€)', 'Bar (€)', 'Gesamt (€)']
 
@@ -114,9 +125,7 @@ function downloadCSV() {
     `${o.vendorName} (${o.vendorLicenseId})`,
     itemSummary(o),
     o.balanceUsed > 0 ? (o.balanceUsed / 100).toFixed(2) : '',
-    (o.cashAmount > 0 ? o.cashAmount : !o.balanceUsed ? o.totalAmount : 0) > 0
-      ? ((o.cashAmount || o.totalAmount) / 100).toFixed(2)
-      : '',
+    cashPaid(o) > 0 ? (cashPaid(o) / 100).toFixed(2) : '',
     ((o.totalAmount || o.balanceUsed) / 100).toFixed(2)
   ])
 

--- a/src/views/backoffice/BackofficeProductNew.vue
+++ b/src/views/backoffice/BackofficeProductNew.vue
@@ -12,6 +12,7 @@ const { t } = useI18n()
 
 const store = useItemsStore()
 const settingsStore = useSettingsStore()
+
 const availableItemTypes = computed(() =>
   ITEM_TYPES.filter((type) => type !== 'abonement' || settingsStore.settings.AbonementEnabled)
 )

--- a/src/views/backoffice/BackofficeProductUpdate.vue
+++ b/src/views/backoffice/BackofficeProductUpdate.vue
@@ -14,9 +14,11 @@ import { useRoute } from 'vue-router'
 const itemsStore = useItemsStore()
 const keycloakStore = useKeycloakStore()
 const settingsStore = useSettingsStore()
+
 const availableItemTypes = computed(() =>
   ITEM_TYPES.filter((type) => type !== 'abonement' || settingsStore.settings.AbonementEnabled)
 )
+
 const authenticated = computed(() => keycloakStore.authenticated)
 
 const updatedItem = ref<Item | null>()


### PR DESCRIPTION
## Problem

With `ShopLanding` enabled, `/v/:id/landing-page` is supposed to immediately redirect to `/v/:id/shop`. Instead it hangs on a blank page and never navigates.

## Root cause

`getSettingsFromApi()` in `src/stores/settings.ts` was declared `async` but never awaited or returned the `fetchSettings()` promise, so a caller's `.then()`/`await` resolved **before** the settings were actually loaded.

On the landing page this meant the `ShopLanding` redirect check ran while `ShopLanding` was still `undefined`, racing the items fetch and usually losing — the template only renders when `ShopLanding !== undefined && !ShopLanding`, so once settings finally arrived with `ShopLanding = true`, nothing re-triggered navigation and the page stayed blank.

Contributing factors:
- The `isLoading` dedup guard was dead — it was checked but never set to `true`.
- `DefaultLayout` fires a second concurrent `getSettingsFromApi()` call, compounding the race.

## Fix

- `getSettingsFromApi()` now stores a single shared in-flight request. Concurrent callers await the **same** fetch and only resolve once the settings are populated. `isLoading` is set/cleared correctly.
- `LandingPage.vue`: the direct-reload vendor-id fallback read `route.params.vendorid`, but the route param is `:id`, so it was always `undefined` and pushed a broken `/v//shop`. Fixed to `route.params.id`.
- Small `cashPaid()` refactor in `BackofficePOSAccounting.vue`.

## Verification

- `yarn type-check` passes.
- `yarn build` passes on the current `main` base.
- Changed files are lint-clean (`yarn eslint`).