### PR TITLE
Add vendor ID column to vendors CSV export

### DIFF
--- a/src/views/backoffice/BackofficeVendorsSummary.vue
+++ b/src/views/backoffice/BackofficeVendorsSummary.vue
@@ -51,10 +51,11 @@ const exportTable = () => {
     return
   }
 
-  const header = ['Ausweisnummer', 'Vorname', 'Nachname', 'Aktuelles Guthaben']
+  const header = ['ID', 'Ausweisnummer', 'Vorname', 'Nachname', 'Aktuelles Guthaben']
 
   const data = displayVendors.value.map((vendor: Vendor) => {
     return [
+      vendor.ID,
       vendor.LicenseID,
       vendor.FirstName,
       vendor.LastName,


### PR DESCRIPTION
## What

Adds the internal vendor `ID` as the first column of the vendors CSV export in the backoffice vendors summary.

Previously the export only included `Ausweisnummer` (LicenseID), first name, last name, and current credit. The internal `ID` is now included so exported rows can be cross-referenced with vendor profiles and other systems.

## Changes

- `BackofficeVendorsSummary.vue`: add `ID` to the CSV header and `vendor.ID` to each exported row.