### PR TITLE
Import vendor locations and comments, add demo CSV

### DIFF
--- a/Vendor_import.csv
+++ b/Vendor_import.csv
@@ -1,0 +1,13 @@
+PLZ;Station/Supermarkt;Adresse;Longitude;Latitude;Arbeitszeit;Ausweis Nr.;Vorname;Nachname;Nummer;Sprache;Registrierungsdatum;VerkäuferIn seit;Kommentar;Auf die Karte?;Hat ein Smartphone?;Hat ein Konto;Schulden
+1010;Billa Stephansplatz;Stephansplatz 4;16.3725;48.2082;Mo-Fr 08:00-12:00;A-201;Marija;Novak;+436641234501;deutsch/kroatisch;2024-01-15;2024-01-15;Stammplatz am Vormittag;Ja;Ja;Ja;0
+1020;Spar Praterstern;Praterstern 1;16.3919;48.2185;Mo-Sa 13:00-18:00;A-202;Ion;Popescu;+436641234502;rumänisch/deutsch;2024-02-01;2024-02-01;;Ja;Nein;Ja;0
+1030;Hofer Landstraße;Landstraßer Hauptstraße 99;16.3947;48.1966;Di,Do 09:00-13:00;A-203;Erzsebet;Kovacs;+436641234503;ungarisch/deutsch;2024-02-12;2024-02-12;Braucht einen Ersatzausweis;Nein;Ja;Nein;15,00
+1040;Billa Wiedner Hauptstraße;Wiedner Hauptstraße 40;16.3661;48.1938;Sa,So 10:00-16:00;A-204;Ahmed;Yilmaz;+436641234504;türkisch/deutsch;2024-03-04;2024-03-04;Verkauft meist am Wochenende;Ja;Ja;Ja;0
+1050;Penny Margaretenplatz;Margaretenplatz 3;16.3578;48.1889;;A-205;Petra;Horvath;+436641234505;deutsch;2024-03-18;2024-03-18;;Ja;Nein;Ja;0
+1060;Spar Mariahilfer Straße;Mariahilfer Straße 77;16.3510;48.1966;Mo-Fr 13:00-17:00;A-206;Dumitru;Ionescu;+436641234506;rumänisch;2024-04-02;2024-04-02;Sprachkurs seit April;Nein;Nein;Nein;7,50
+1070;Billa Neubaugasse;Neubaugasse 25;16.3486;48.2010;Mo-So;A-207;Slavica;Jovanovic;+436641234507;serbisch/deutsch;2024-04-22;2024-04-22;;Ja;Ja;Ja;0
+1080;Hofer Josefstädter Straße;Josefstädter Straße 43;16.3454;48.2107;Mo,Mi,Fr 14:00-18:00;A-208;Miroslav;Kolar;+436641234508;slowakisch/deutsch;2024-05-06;2024-05-06;Nur Nachmittagsschicht möglich;Ja;Nein;Ja;0
+1090;Billa Nußdorfer Straße;Nußdorfer Straße 12;16.3576;48.2245;09:00-17:00;A-209;Fatima;Hassan;+436641234509;arabisch/englisch;2024-05-27;2024-05-27;Dolmetsch bei Terminen nötig;Ja;Ja;Nein;22,00
+1100;Spar Reumannplatz;Reumannplatz 8;16.3762;48.1737;Mo-Fr 07:30-11:30;A-210;Ganna;Shevchenko;+436641234510;ukrainisch/deutsch;2024-06-10;2024-06-10;;Ja;Ja;Ja;0
+1110;Penny Simmeringer Hauptstraße;Simmeringer Hauptstraße 96;16.4218;48.1721;Do-Sa 12:00-20:00;A-211;Rafael;Silva;+436641234511;portugiesisch/englisch;2024-06-24;2024-06-24;Neu im Team;Nein;Ja;Ja;0
+1120;Billa Meidlinger Hauptstraße;Meidlinger Hauptstraße 31;16.3311;48.1794;G;A-212;Anna;Weber;+436641234512;deutsch;2024-07-08;2024-07-08;Vertretung für A-205;Ja;Nein;Ja;0

--- a/src/components/AddressModal.vue
+++ b/src/components/AddressModal.vue
@@ -3,36 +3,12 @@ import type { VendorLocation } from '@/stores/vendor'
 import { computed, onMounted, ref, type Ref } from 'vue'
 import VendorMapView from '@/components/VendorMapView.vue'
 import { useSettingsStore } from '@/stores/settings'
+import { createDefaultWorkingTime, normalizeWorkingTime } from '@/utils/workingTime'
 
 const settingsStore = useSettingsStore()
 const props = defineProps(['vendor', 'locations'])
 const updatedVendor = ref(props.vendor)
 const emit = defineEmits(['close', 'update'])
-
-const createDefaultWorkingTime = () => ({
-  mode: 'everyday',
-  everyday: [{ from: '09:00', to: '17:00' }]
-})
-
-const normalizeWorkingTime = (workingTime: VendorLocation['working_time']) => {
-  if (!workingTime || typeof workingTime === 'string') {
-    switch (workingTime) {
-      case 'G':
-      case 'g':
-        return { mode: 'whole_week', whole_week: true }
-      case 'V':
-      case 'v':
-        return { mode: 'everyday', everyday: [{ from: '08:00', to: '12:00' }] }
-      case 'N':
-      case 'n':
-        return { mode: 'everyday', everyday: [{ from: '13:00', to: '17:00' }] }
-      default:
-        return createDefaultWorkingTime()
-    }
-  }
-
-  return workingTime
-}
 
 const newAddress: Ref<VendorLocation> = ref({
   id: 0,

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -347,6 +347,8 @@
   "posOrderCount": "Anzahl Verkäufe",
   "posItemTotals": "Artikel gesamt",
   "downloadCSV": "CSV herunterladen",
+  "downloadDemoCSV": "Demo-CSV herunterladen",
+  "CSV import": "CSV importieren",
   "Branding": "Markenauftritt",
   "Webshop": "Webshop",
   "productId": "ID",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -258,6 +258,8 @@
   "posOrderCount": "Number of sales",
   "posItemTotals": "Item totals",
   "downloadCSV": "Download CSV",
+  "downloadDemoCSV": "Download demo CSV",
+  "CSV import": "CSV import",
   "Branding": "Branding",
   "Webshop": "Webshop",
   "productId": "ID",

--- a/src/stores/vendor.ts
+++ b/src/stores/vendor.ts
@@ -19,6 +19,8 @@ import {
   deleteVendorComment,
   recalculateVendorBalances
 } from '@/api/api'
+import type { VendorCsvRow } from '@/utils/vendorCsv'
+import { buildComment, buildLocation, hasLocation } from '@/utils/vendorCsv'
 import router from '@/router'
 
 export const useVendorStore = defineStore('vendor', {
@@ -208,7 +210,7 @@ export const vendorsStore = defineStore('vendors', {
       return postVendors(newVendor)
     },
 
-    async createVendors(vendors: Array<Vendor>) {
+    async createVendors(vendors: Array<VendorCsvRow>) {
       for (let i = 0; i < vendors.length; i++) {
         const vendor = vendors[i]
 
@@ -225,8 +227,41 @@ export const vendorsStore = defineStore('vendors', {
           const vendorCheck = await checkVendorId(vendor.LicenseID)
 
           if (vendorCheck === null) {
-            await this.createVendorPromise(vendor)
+            const response = await this.createVendorPromise(vendor as unknown as Vendor)
+
+            await this.createImportedVendorDetails(response?.data, vendor)
           }
+        }
+      }
+    },
+
+    /**
+     * Standplatz and Kommentar are separate resources — creating the vendor does not create them,
+     * so the import has to post them once the new vendor id is known. A failure here must not
+     * abort the rest of the import: the vendor itself already exists.
+     */
+    async createImportedVendorDetails(vendorId: unknown, vendor: VendorCsvRow) {
+      if (typeof vendorId !== 'number' || vendorId <= 0) {
+        // eslint-disable-next-line no-console
+        console.error('Vendor import: no vendor id returned for', vendor.LicenseID)
+        return
+      }
+
+      if (hasLocation(vendor)) {
+        try {
+          await postVendorLocation(vendorId, buildLocation(vendor))
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error('Vendor import: location failed for', vendor.LicenseID, error)
+        }
+      }
+
+      if (vendor.Comment !== '') {
+        try {
+          await postVendorComment(vendorId, buildComment(vendor))
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error('Vendor import: comment failed for', vendor.LicenseID, error)
         }
       }
     },

--- a/src/utils/__tests__/vendorCsv.spec.ts
+++ b/src/utils/__tests__/vendorCsv.spec.ts
@@ -1,0 +1,427 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { VendorCsvRow } from '@/utils/vendorCsv'
+import {
+  buildVendorCsvTemplate,
+  downloadVendorCsvTemplate,
+  hasLocation,
+  parseVendorsCsv,
+  VENDOR_CSV_COLUMNS,
+  VENDOR_CSV_TEMPLATE_FILENAME
+} from '@/utils/vendorCsv'
+// The sample file shipped for backoffice users — the test imports the real file so the two cannot
+// drift apart.
+import sampleCsv from '../../../Vendor_import.csv?raw'
+
+// The backend answers a vendor creation with the new vendor id — locations and comments are hung
+// off that id afterwards.
+let lastVendorId = 0
+const postVendors = vi.fn((_vendor: VendorCsvRow) => Promise.resolve({ data: ++lastVendorId }))
+
+const checkVendorId = vi.fn((_licenseId: string) => Promise.resolve<{ name: string } | null>(null))
+
+const postVendorLocation = vi.fn((_vendorId: number, _location: unknown) =>
+  Promise.resolve({ data: {} })
+)
+
+const postVendorComment = vi.fn((_vendorId: number, _comment: unknown) =>
+  Promise.resolve({ data: {} })
+)
+
+// The vendor store pulls in the axios/keycloak api layer and the router, neither of which we want
+// to boot for a unit test — the import path we care about is parse -> createVendors -> postVendors.
+vi.mock('@/api/api', () => ({
+  postVendors,
+  checkVendorId,
+  getVendor: vi.fn(),
+  fetchVendors: vi.fn(() => Promise.resolve({ data: [] })),
+  patchVendor: vi.fn(),
+  removeVendor: vi.fn(),
+  getVendorMe: vi.fn(),
+  patchVendorLocation: vi.fn(),
+  postVendorLocation,
+  deleteVendorLocation: vi.fn(),
+  fetchVendorLocations: vi.fn(),
+  fetchVendorComments: vi.fn(),
+  postVendorComment,
+  patchVendorComment: vi.fn(),
+  deleteVendorComment: vi.fn(),
+  recalculateVendorBalances: vi.fn()
+}))
+
+vi.mock('@/api/agent', () => ({ default: {} }))
+vi.mock('@/router', () => ({ default: { push: vi.fn() } }))
+
+const EMAIL_POSTFIX = '@augustin.or.at'
+
+describe('parseVendorsCsv', () => {
+  it('parses every data row of the shipped sample file', () => {
+    const dataLines = sampleCsv
+      .split('\n')
+      .slice(1)
+      .filter((line) => line.trim() !== '')
+
+    const vendors = parseVendorsCsv(sampleCsv, EMAIL_POSTFIX)
+
+    expect(dataLines.length).toBeGreaterThan(1)
+    expect(vendors).toHaveLength(dataLines.length)
+    expect(vendors.every((vendor) => vendor.LicenseID !== '')).toBe(true)
+  })
+
+  it('has a sample file matching the documented column order', () => {
+    const header = sampleCsv.split('\n')[0]?.trim().split(';')
+
+    expect(header).toEqual([...VENDOR_CSV_COLUMNS])
+  })
+
+  it('maps every column of a row onto the vendor payload', () => {
+    const csv = [
+      VENDOR_CSV_COLUMNS.join(';'),
+      '1010;Billa Stephansplatz;Stephansplatz 4;16.3725;48.2082;G;A-201;Marija;Novak;' +
+        '+436641234501;deutsch/kroatisch;2024-01-15;2024-01-15;Stammplatz am Vormittag;Ja;Ja;Ja;0'
+    ].join('\n')
+
+    expect(parseVendorsCsv(csv, EMAIL_POSTFIX)[0]).toEqual({
+      PLZ: '1010',
+      Location: 'Billa Stephansplatz',
+      Address: 'Stephansplatz 4',
+      Longitude: 16.3725,
+      Latitude: 48.2082,
+      WorkingTime: 'G',
+      LicenseID: 'A-201',
+      FirstName: 'Marija',
+      LastName: 'Novak',
+      Telephone: '+436641234501',
+      Language: 'deutsch/kroatisch',
+      RegistrationDate: '2024-01-15',
+      VendorSince: '2024-01-15',
+      Comment: 'Stammplatz am Vormittag',
+      LastPayout: null,
+      UrlID: '',
+      OnlineMap: true,
+      HasSmartphone: true,
+      HasBankAccount: true,
+      IsDisabled: false,
+      Email: 'A-201@augustin.or.at',
+      Debt: '0'
+    })
+  })
+
+  it('derives the email from the license id and the configured postfix', () => {
+    const vendors = parseVendorsCsv(sampleCsv, EMAIL_POSTFIX)
+
+    for (const vendor of vendors) {
+      expect(vendor.Email).toBe(`${vendor.LicenseID}${EMAIL_POSTFIX}`)
+    }
+  })
+
+  it('keeps license ids unique so the import does not collide on emails', () => {
+    const licenseIds = parseVendorsCsv(sampleCsv, EMAIL_POSTFIX).map((vendor) => vendor.LicenseID)
+
+    expect(new Set(licenseIds).size).toBe(licenseIds.length)
+  })
+
+  it('falls back to defaults for empty coordinates and working time', () => {
+    const csv = [
+      VENDOR_CSV_COLUMNS.join(';'),
+      '1050;Penny;Margaretenplatz 3;;;;A-205;Petra;Horvath;;deutsch;2024-03-18;2024-03-18;;Ja;Nein;Ja;0'
+    ].join('\n')
+
+    const vendor = parseVendorsCsv(csv, EMAIL_POSTFIX)[0]
+
+    expect(vendor?.Longitude).toBe(0.1)
+    expect(vendor?.Latitude).toBe(0.1)
+    expect(vendor?.WorkingTime).toBe('G')
+  })
+
+  it('reads decimal commas as written by German Excel', () => {
+    const csv = [
+      VENDOR_CSV_COLUMNS.join(';'),
+      '1030;Hofer;Landstraße 99;16,3947;48,1966;G;A-203;Erzsebet;Kovacs;;deutsch;2024-02-12;2024-02-12;;Nein;Ja;Nein;15,00'
+    ].join('\n')
+
+    const vendor = parseVendorsCsv(csv, EMAIL_POSTFIX)[0]
+
+    expect(vendor?.Longitude).toBeCloseTo(16.3947)
+    expect(vendor?.Latitude).toBeCloseTo(48.1966)
+  })
+
+  it('reads the yes/no columns in both languages and casing', () => {
+    const row = (onlineMap: string, smartphone: string, bankAccount: string) =>
+      `1010;Billa;Gasse 1;1;1;G;A-1;Test;Person;;deutsch;2024-01-01;2024-01-01;;${onlineMap};${smartphone};${bankAccount};0`
+
+    const vendors = parseVendorsCsv(
+      [
+        VENDOR_CSV_COLUMNS.join(';'),
+        row('Ja', 'ja', 'yes'),
+        row('Nein', 'nein', 'no'),
+        row('', '', '')
+      ].join('\n'),
+      EMAIL_POSTFIX
+    )
+
+    expect(vendors[0]).toMatchObject({ OnlineMap: true, HasSmartphone: true, HasBankAccount: true })
+
+    expect(vendors[1]).toMatchObject({
+      OnlineMap: false,
+      HasSmartphone: false,
+      HasBankAccount: false
+    })
+
+    expect(vendors[2]).toMatchObject({
+      OnlineMap: false,
+      HasSmartphone: false,
+      HasBankAccount: false
+    })
+  })
+
+  it('ignores the header, blank lines and rows without a license id', () => {
+    const csv = [
+      VENDOR_CSV_COLUMNS.join(';'),
+      '1010;Billa;Gasse 1;1;1;G;A-1;Test;Person;;deutsch;2024-01-01;2024-01-01;;Ja;Ja;Ja;0',
+      '',
+      '1020;Spar;Gasse 2;1;1;G;;Ohne;Ausweis;;deutsch;2024-01-01;2024-01-01;;Ja;Ja;Ja;0',
+      '   ',
+      ''
+    ].join('\n')
+
+    const vendors = parseVendorsCsv(csv, EMAIL_POSTFIX)
+
+    expect(vendors).toHaveLength(1)
+    expect(vendors[0]?.LicenseID).toBe('A-1')
+  })
+
+  it('handles CRLF line endings and padded cells', () => {
+    const csv =
+      `${VENDOR_CSV_COLUMNS.join(';')}\r\n` +
+      '1010; Billa ;Gasse 1;1;1;G; A-1 ; Test ; Person ;;deutsch;2024-01-01;2024-01-01;;Ja;Ja;Ja;0\r\n'
+
+    const vendors = parseVendorsCsv(csv, EMAIL_POSTFIX)
+
+    expect(vendors).toHaveLength(1)
+
+    expect(vendors[0]).toMatchObject({
+      Location: 'Billa',
+      LicenseID: 'A-1',
+      FirstName: 'Test',
+      LastName: 'Person',
+      Email: `A-1${EMAIL_POSTFIX}`,
+      Debt: '0'
+    })
+  })
+})
+
+describe('the demo CSV offered for download', () => {
+  it('can be imported again without losing a single vendor', () => {
+    // The download carries a UTF-8 BOM for Excel — it must not turn up in the first vendor.
+    expect(buildVendorCsvTemplate().startsWith('\ufeff')).toBe(true)
+
+    expect(parseVendorsCsv(buildVendorCsvTemplate(), EMAIL_POSTFIX)).toEqual(
+      parseVendorsCsv(sampleCsv, EMAIL_POSTFIX)
+    )
+  })
+
+  it('is handed to the browser as a csv download', () => {
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+    const appendChild = vi.spyOn(document.body, 'appendChild')
+
+    downloadVendorCsvTemplate()
+
+    expect(click).toHaveBeenCalledOnce()
+
+    const anchor = appendChild.mock.calls[0]?.[0] as HTMLAnchorElement
+
+    expect(anchor.download).toBe(VENDOR_CSV_TEMPLATE_FILENAME)
+
+    expect(decodeURIComponent(anchor.href.replace('data:text/csv;charset=utf-8,', ''))).toBe(
+      buildVendorCsvTemplate()
+    )
+
+    // The anchor is a means to an end and must not linger in the DOM.
+    expect(document.body.contains(anchor)).toBe(false)
+
+    click.mockRestore()
+    appendChild.mockRestore()
+  })
+})
+
+describe('importing the sample file through the vendor store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    lastVendorId = 0
+    postVendors.mockClear()
+    postVendorLocation.mockClear()
+    postVendorComment.mockClear()
+    checkVendorId.mockClear()
+    checkVendorId.mockImplementation(() => Promise.resolve(null))
+  })
+
+  it('creates every vendor of the sample file', async () => {
+    const { vendorsStore } = await import('@/stores/vendor')
+    const store = vendorsStore()
+    const vendors = parseVendorsCsv(sampleCsv, EMAIL_POSTFIX)
+
+    await store.createVendors(vendors)
+
+    expect(postVendors).toHaveBeenCalledTimes(vendors.length)
+    expect(store.vendorsImportedCount).toBe(vendors.length)
+
+    const posted = postVendors.mock.calls.map(([vendor]) => vendor)
+    expect(posted).toEqual(vendors)
+  })
+
+  it('skips vendors whose license id already exists', async () => {
+    const { vendorsStore } = await import('@/stores/vendor')
+    const store = vendorsStore()
+    const vendors = parseVendorsCsv(sampleCsv, EMAIL_POSTFIX)
+    const existing = vendors[0]?.LicenseID
+
+    checkVendorId.mockImplementation((licenseId: string) =>
+      Promise.resolve(licenseId === existing ? { name: 'Marija' } : null)
+    )
+
+    await store.createVendors(vendors)
+
+    expect(postVendors).toHaveBeenCalledTimes(vendors.length - 1)
+    expect(postVendors.mock.calls.map(([vendor]) => vendor.LicenseID)).not.toContain(existing)
+  })
+
+  it('creates the Standplatz of every vendor against the id it just got back', async () => {
+    const { vendorsStore } = await import('@/stores/vendor')
+    const store = vendorsStore()
+    const vendors = parseVendorsCsv(sampleCsv, EMAIL_POSTFIX)
+
+    await store.createVendors(vendors)
+
+    // Every row of the sample names a Standplatz.
+    expect(vendors.filter(hasLocation)).toHaveLength(vendors.length)
+    expect(postVendorLocation).toHaveBeenCalledTimes(vendors.length)
+
+    // Ids are handed out in order, so the nth location must belong to the nth vendor.
+    expect(postVendorLocation.mock.calls.map(([vendorId]) => vendorId)).toEqual(
+      vendors.map((_vendor, index) => index + 1)
+    )
+
+    expect(postVendorLocation.mock.calls[0]?.[1]).toEqual({
+      id: 0,
+      name: 'Billa Stephansplatz',
+      address: 'Stephansplatz 4',
+      zip: '1010',
+      longitude: 16.3725,
+      latitude: 48.2082,
+      working_time: {
+        mode: 'by_day',
+        week_days: {
+          mon: [{ from: '08:00', to: '12:00' }],
+          tue: [{ from: '08:00', to: '12:00' }],
+          wed: [{ from: '08:00', to: '12:00' }],
+          thu: [{ from: '08:00', to: '12:00' }],
+          fri: [{ from: '08:00', to: '12:00' }]
+        }
+      }
+    })
+  })
+
+  it('turns every written working time of the sample into a structured one', async () => {
+    const { vendorsStore } = await import('@/stores/vendor')
+    const store = vendorsStore()
+    const vendors = parseVendorsCsv(sampleCsv, EMAIL_POSTFIX)
+
+    await store.createVendors(vendors)
+
+    const workingTimeOf = (written: string) => {
+      const index = vendors.findIndex((vendor) => vendor.WorkingTime === written)
+
+      expect(index, `sample has no row with working time "${written}"`).toBeGreaterThan(-1)
+
+      return (postVendorLocation.mock.calls[index]?.[1] as { working_time: unknown }).working_time
+    }
+
+    // The sample covers every accepted spelling on purpose.
+    expect(workingTimeOf('Di,Do 09:00-13:00')).toEqual({
+      mode: 'by_day',
+      week_days: {
+        tue: [{ from: '09:00', to: '13:00' }],
+        thu: [{ from: '09:00', to: '13:00' }]
+      }
+    })
+
+    expect(workingTimeOf('09:00-17:00')).toEqual({
+      mode: 'everyday',
+      everyday: [{ from: '09:00', to: '17:00' }]
+    })
+
+    expect(workingTimeOf('Mo-So')).toEqual({ mode: 'whole_week', whole_week: true })
+    expect(workingTimeOf('G')).toEqual({ mode: 'whole_week', whole_week: true })
+
+    // None of them may reach the backend as plain text.
+    for (const [, location] of postVendorLocation.mock.calls) {
+      expect(typeof (location as { working_time: unknown }).working_time).toBe('object')
+    }
+  })
+
+  it('creates a comment only for the rows that carry one', async () => {
+    const { vendorsStore } = await import('@/stores/vendor')
+    const store = vendorsStore()
+    const vendors = parseVendorsCsv(sampleCsv, EMAIL_POSTFIX)
+    const commented = vendors.filter((vendor) => vendor.Comment !== '')
+
+    await store.createVendors(vendors)
+
+    // The sample deliberately leaves some comments empty — those must not create an empty comment.
+    expect(commented.length).toBeLessThan(vendors.length)
+    expect(postVendorComment).toHaveBeenCalledTimes(commented.length)
+
+    expect(postVendorComment.mock.calls[0]?.[1]).toEqual({
+      comment: 'Stammplatz am Vormittag',
+      warning: false
+    })
+  })
+
+  it('leaves locations and comments alone for vendors that already exist', async () => {
+    const { vendorsStore } = await import('@/stores/vendor')
+    const store = vendorsStore()
+    const vendors = parseVendorsCsv(sampleCsv, EMAIL_POSTFIX)
+
+    checkVendorId.mockImplementation(() => Promise.resolve({ name: 'schon da' }))
+
+    await store.createVendors(vendors)
+
+    expect(postVendors).not.toHaveBeenCalled()
+    expect(postVendorLocation).not.toHaveBeenCalled()
+    expect(postVendorComment).not.toHaveBeenCalled()
+  })
+
+  it('imports a row without Standplatz and comment as a plain vendor', async () => {
+    const { vendorsStore } = await import('@/stores/vendor')
+    const store = vendorsStore()
+
+    const csv = [
+      VENDOR_CSV_COLUMNS.join(';'),
+      ';;;;;;A-1;Test;Person;;deutsch;2024-01-01;2024-01-01;;Nein;Nein;Nein;0'
+    ].join('\n')
+
+    await store.createVendors(parseVendorsCsv(csv, EMAIL_POSTFIX))
+
+    expect(postVendors).toHaveBeenCalledOnce()
+    expect(postVendorLocation).not.toHaveBeenCalled()
+    expect(postVendorComment).not.toHaveBeenCalled()
+  })
+
+  it('keeps importing the remaining vendors when a Standplatz cannot be created', async () => {
+    const { vendorsStore } = await import('@/stores/vendor')
+    const store = vendorsStore()
+    const vendors = parseVendorsCsv(sampleCsv, EMAIL_POSTFIX)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    postVendorLocation.mockRejectedValueOnce(new Error('location endpoint down'))
+
+    await store.createVendors(vendors)
+
+    expect(postVendors).toHaveBeenCalledTimes(vendors.length)
+    expect(postVendorLocation).toHaveBeenCalledTimes(vendors.length)
+    expect(consoleError).toHaveBeenCalled()
+
+    consoleError.mockRestore()
+  })
+})

--- a/src/utils/__tests__/workingTime.spec.ts
+++ b/src/utils/__tests__/workingTime.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createDefaultWorkingTime,
+  normalizeWorkingTime,
+  parseWorkingTime
+} from '@/utils/workingTime'
+
+describe('parseWorkingTime', () => {
+  it('reads a weekday range with hours', () => {
+    expect(parseWorkingTime('Mo-Fr 08:00-12:00')).toEqual({
+      mode: 'by_day',
+      week_days: {
+        mon: [{ from: '08:00', to: '12:00' }],
+        tue: [{ from: '08:00', to: '12:00' }],
+        wed: [{ from: '08:00', to: '12:00' }],
+        thu: [{ from: '08:00', to: '12:00' }],
+        fri: [{ from: '08:00', to: '12:00' }]
+      }
+    })
+  })
+
+  it('reads a list of single weekdays', () => {
+    expect(parseWorkingTime('Di,Do 09:00-13:00')).toEqual({
+      mode: 'by_day',
+      week_days: {
+        tue: [{ from: '09:00', to: '13:00' }],
+        thu: [{ from: '09:00', to: '13:00' }]
+      }
+    })
+  })
+
+  it('reads a range and single days in the same cell', () => {
+    expect(parseWorkingTime('Mo-Mi,Sa 10:00-16:00')).toEqual({
+      mode: 'by_day',
+      week_days: {
+        mon: [{ from: '10:00', to: '16:00' }],
+        tue: [{ from: '10:00', to: '16:00' }],
+        wed: [{ from: '10:00', to: '16:00' }],
+        sat: [{ from: '10:00', to: '16:00' }]
+      }
+    })
+  })
+
+  it('keeps the weekdays in week order, however they were written', () => {
+    const workingTime = parseWorkingTime('So,Mi,Sa 10:00-16:00')
+
+    expect(Object.keys(workingTime.week_days ?? {})).toEqual(['wed', 'sat', 'sun'])
+  })
+
+  it('wraps a weekday range around the end of the week', () => {
+    const workingTime = parseWorkingTime('Fr-Mo 12:00-20:00')
+
+    expect(Object.keys(workingTime.week_days ?? {})).toEqual(['mon', 'fri', 'sat', 'sun'])
+  })
+
+  it('treats weekdays without hours as full days', () => {
+    expect(parseWorkingTime('Sa,So')).toEqual({
+      mode: 'by_day',
+      week_days: { sat: [{ full_day: true }], sun: [{ full_day: true }] }
+    })
+  })
+
+  it('treats the full week without hours as ganztags', () => {
+    expect(parseWorkingTime('Mo-So')).toEqual({ mode: 'whole_week', whole_week: true })
+  })
+
+  it('applies hours without weekdays to every day', () => {
+    expect(parseWorkingTime('09:00-17:00')).toEqual({
+      mode: 'everyday',
+      everyday: [{ from: '09:00', to: '17:00' }]
+    })
+  })
+
+  it('pads single digit hours and accepts a dot as separator', () => {
+    expect(parseWorkingTime('8.00-9.30')).toEqual({
+      mode: 'everyday',
+      everyday: [{ from: '08:00', to: '09:30' }]
+    })
+  })
+
+  it('understands English weekday names', () => {
+    expect(parseWorkingTime('Mon-Tue 08:00-12:00')).toEqual({
+      mode: 'by_day',
+      week_days: {
+        mon: [{ from: '08:00', to: '12:00' }],
+        tue: [{ from: '08:00', to: '12:00' }]
+      }
+    })
+  })
+
+  it('still reads the legacy letters of the old import files', () => {
+    expect(parseWorkingTime('G')).toEqual({ mode: 'whole_week', whole_week: true })
+    expect(parseWorkingTime('g')).toEqual({ mode: 'whole_week', whole_week: true })
+
+    expect(parseWorkingTime('V')).toEqual({
+      mode: 'everyday',
+      everyday: [{ from: '08:00', to: '12:00' }]
+    })
+
+    expect(parseWorkingTime('N')).toEqual({
+      mode: 'everyday',
+      everyday: [{ from: '13:00', to: '17:00' }]
+    })
+  })
+
+  it('falls back to the default instead of dropping an unreadable cell', () => {
+    expect(parseWorkingTime('')).toEqual(createDefaultWorkingTime())
+    expect(parseWorkingTime('   ')).toEqual(createDefaultWorkingTime())
+    expect(parseWorkingTime('nach Absprache')).toEqual(createDefaultWorkingTime())
+  })
+})
+
+describe('normalizeWorkingTime', () => {
+  it('leaves an already structured working time untouched', () => {
+    const stored = { mode: 'by_day', week_days: { mon: [{ from: '10:00', to: '14:00' }] } }
+
+    expect(normalizeWorkingTime(stored)).toBe(stored)
+  })
+
+  it('defaults when there is nothing stored', () => {
+    expect(normalizeWorkingTime(null)).toEqual(createDefaultWorkingTime())
+    expect(normalizeWorkingTime(undefined)).toEqual(createDefaultWorkingTime())
+  })
+})

--- a/src/utils/vendorCsv.ts
+++ b/src/utils/vendorCsv.ts
@@ -1,0 +1,172 @@
+import type { VendorLocation } from '@/stores/vendor'
+import { transformToFloat } from '@/utils/utils'
+import { normalizeWorkingTime } from '@/utils/workingTime'
+import sampleCsv from '../../Vendor_import.csv?raw'
+
+/**
+ * Column order expected in the vendor import CSV (semicolon separated, first line is the header).
+ * See Vendor_import.csv in the repository root for a sample file.
+ */
+export const VENDOR_CSV_COLUMNS = [
+  'PLZ',
+  'Station/Supermarkt',
+  'Adresse',
+  'Longitude',
+  'Latitude',
+  'Arbeitszeit',
+  'Ausweis Nr.',
+  'Vorname',
+  'Nachname',
+  'Nummer',
+  'Sprache',
+  'Registrierungsdatum',
+  'VerkäuferIn seit',
+  'Kommentar',
+  'Auf die Karte?',
+  'Hat ein Smartphone?',
+  'Hat ein Konto',
+  'Schulden'
+] as const
+
+/** A single vendor as parsed from the import CSV. */
+export interface VendorCsvRow {
+  PLZ: string
+  Location: string
+  Address: string
+  Longitude: number
+  Latitude: number
+  WorkingTime: string
+  LicenseID: string
+  FirstName: string
+  LastName: string
+  Telephone: string
+  Language: string
+  RegistrationDate: string
+  VendorSince: string
+  Comment: string
+  LastPayout: null
+  UrlID: string
+  OnlineMap: boolean
+  HasSmartphone: boolean
+  HasBankAccount: boolean
+  IsDisabled: boolean
+  Email: string
+  Debt: string
+}
+
+/**
+ * The Standplatz columns describe a location, which the backend stores separately from the vendor —
+ * the vendor payload has no address fields. A row only gets a location when it names one.
+ */
+export function hasLocation(vendor: VendorCsvRow): boolean {
+  return vendor.Location !== '' || vendor.Address !== '' || vendor.PLZ !== ''
+}
+
+export function buildLocation(vendor: VendorCsvRow): VendorLocation {
+  return {
+    id: 0,
+    name: vendor.Location,
+    address: vendor.Address,
+    zip: vendor.PLZ,
+    longitude: vendor.Longitude,
+    latitude: vendor.Latitude,
+    working_time: normalizeWorkingTime(vendor.WorkingTime)
+  }
+}
+
+/** Comments are a separate resource as well, and only rows that carry one get it. */
+export function buildComment(vendor: VendorCsvRow): { comment: string; warning: boolean } {
+  return { comment: vendor.Comment, warning: false }
+}
+
+export const VENDOR_CSV_TEMPLATE_FILENAME = 'Vendor_import.csv'
+
+/** Excel only reads the umlauts correctly when the file starts with a UTF-8 BOM. */
+const UTF8_BOM = '\ufeff'
+
+/**
+ * The sample file shipped with the frontend, ready to be handed to a backoffice user.
+ * It is the same file the parser tests run against, so what gets downloaded always imports.
+ */
+export function buildVendorCsvTemplate(): string {
+  return `${UTF8_BOM}${sampleCsv}`
+}
+
+/** Offers the sample file as a download. */
+export function downloadVendorCsvTemplate(): void {
+  const anchor = document.createElement('a')
+  anchor.href = 'data:text/csv;charset=utf-8,' + encodeURIComponent(buildVendorCsvTemplate())
+  anchor.target = '_blank'
+  anchor.style.visibility = 'hidden'
+  anchor.download = VENDOR_CSV_TEMPLATE_FILENAME
+  document.body.appendChild(anchor)
+  anchor.click()
+  document.body.removeChild(anchor)
+}
+
+const isYes = (value: string): boolean => {
+  const normalized = value.toLowerCase()
+  return normalized === 'ja' || normalized === 'yes'
+}
+
+/**
+ * Parses the vendor import CSV into vendors ready to be sent to the backend.
+ *
+ * The first line is treated as a header and skipped. Blank lines are ignored, so a file with a
+ * trailing newline does not produce an empty vendor. Rows without a license id are dropped as
+ * well — the store aborts the whole import when it hits a vendor without one.
+ */
+export function parseVendorsCsv(text: string, emailPostfix: string): VendorCsvRow[] {
+  return text
+    .split('\n')
+    .slice(1)
+    .filter((line) => line.trim() !== '')
+    .map((line) => {
+      const [
+        PLZ,
+        Location,
+        Address,
+        Longitude,
+        Latitude,
+        WorkingTime,
+        LicenseID,
+        FirstName,
+        LastName,
+        Telephone,
+        Language,
+        RegistrationDate,
+        VendorSince,
+        Comment,
+        OnlineMap,
+        HasSmartphone,
+        HasBankAccount,
+        Debt
+      ] = line.split(';').map((field) => field.trim())
+
+      return {
+        PLZ: PLZ ?? '',
+        Location: Location ?? '',
+        Address: Address ?? '',
+        Longitude: !Longitude ? 0.1 : transformToFloat(Longitude),
+        Latitude: !Latitude ? 0.1 : transformToFloat(Latitude),
+        WorkingTime: !WorkingTime ? 'G' : WorkingTime,
+        LicenseID: LicenseID ?? '',
+        FirstName: FirstName ?? '',
+        LastName: LastName ?? '',
+        Telephone: Telephone ?? '',
+        Language: Language ?? '',
+        RegistrationDate: RegistrationDate ?? '',
+        VendorSince: VendorSince ?? '',
+        Comment: Comment ?? '',
+        LastPayout: null,
+        UrlID: '',
+        OnlineMap: isYes(OnlineMap ?? ''),
+        HasSmartphone: isYes(HasSmartphone ?? ''),
+        HasBankAccount: isYes(HasBankAccount ?? ''),
+        IsDisabled: false,
+        Email: `${LicenseID ?? ''}${emailPostfix}`,
+        Debt: Debt ?? ''
+      }
+    })
+    .filter((vendor) => vendor.LicenseID !== '')
+}

--- a/src/utils/workingTime.ts
+++ b/src/utils/workingTime.ts
@@ -1,0 +1,144 @@
+export interface TimeRange {
+  from?: string
+  to?: string
+  full_day?: boolean
+}
+
+export interface WorkingTime {
+  mode?: string
+  everyday?: TimeRange[]
+  week_days?: { [key: string]: TimeRange[] }
+  whole_week?: boolean
+}
+
+/** Weekday keys as the backend stores them, in week order, with the spellings accepted for each. */
+const DAY_ALIASES: { [day: string]: string[] } = {
+  mon: ['mo', 'mon', 'montag', 'monday'],
+  tue: ['di', 'tue', 'dienstag', 'tuesday'],
+  wed: ['mi', 'wed', 'mittwoch', 'wednesday'],
+  thu: ['do', 'thu', 'donnerstag', 'thursday'],
+  fri: ['fr', 'fri', 'freitag', 'friday'],
+  sat: ['sa', 'sat', 'samstag', 'saturday'],
+  sun: ['so', 'sun', 'sonntag', 'sunday']
+}
+
+const WEEK_DAYS = Object.keys(DAY_ALIASES)
+
+const dayKey = (name: string): string | undefined =>
+  WEEK_DAYS.find((day) => DAY_ALIASES[day]?.includes(name))
+
+/** "08:00-12:00", "8.00 - 12.00", "08:00 – 12:00" */
+const TIME_RANGE = /(\d{1,2})[:.](\d{2})\s*[-–]\s*(\d{1,2})[:.](\d{2})/
+
+export const createDefaultWorkingTime = (): WorkingTime => ({
+  mode: 'everyday',
+  everyday: [{ from: '09:00', to: '17:00' }]
+})
+
+const wholeWeek = (): WorkingTime => ({ mode: 'whole_week', whole_week: true })
+
+const everyday = (from: string, to: string): WorkingTime => ({
+  mode: 'everyday',
+  everyday: [{ from, to }]
+})
+
+const readTimeRange = (value: string): TimeRange | null => {
+  const match = TIME_RANGE.exec(value)
+
+  if (!match) return null
+
+  const [, fromHour, fromMinute, toHour, toMinute] = match
+
+  return {
+    from: `${(fromHour ?? '').padStart(2, '0')}:${fromMinute}`,
+    to: `${(toHour ?? '').padStart(2, '0')}:${toMinute}`
+  }
+}
+
+/** Expands "mon" through "fri" — wrapping around the end of the week, so "fri-mon" works too. */
+const expandDayRange = (start: string, end: string): string[] => {
+  const first = WEEK_DAYS.indexOf(start)
+  const last = WEEK_DAYS.indexOf(end)
+  const days: string[] = []
+
+  for (let i = 0; i < WEEK_DAYS.length; i++) {
+    const day = WEEK_DAYS[(first + i) % WEEK_DAYS.length]
+
+    if (day) days.push(day)
+    if ((first + i) % WEEK_DAYS.length === last) break
+  }
+
+  return days
+}
+
+/** Reads "Mo-Fr", "Di,Do" or "Mo-Mi,Sa" — the time range, if any, is ignored here. */
+const readDays = (value: string): string[] => {
+  const days: string[] = []
+
+  for (const part of value.replace(TIME_RANGE, ' ').split(/[,+/]/)) {
+    const [start, end] = part.split(/[-–]/).map((day) => dayKey(day.trim().toLowerCase()))
+
+    if (!start) continue
+
+    for (const day of end ? expandDayRange(start, end) : [start]) {
+      if (!days.includes(day)) days.push(day)
+    }
+  }
+
+  return days
+}
+
+/**
+ * Reads a working time as written in the vendor import CSV. Accepted:
+ *
+ * - `Mo-Fr 08:00-12:00`, `Di,Do 09:00-13:00`, `Mo-Mi,Sa 10:00-16:00` — those days, those hours
+ * - `Mo-Fr` — those days, all day
+ * - `08:00-12:00` — every day, those hours
+ * - `Mo-So`, `ganztags`, and the legacy letters `G` / `V` / `N`
+ *
+ * Anything unreadable falls back to the same default the address dialog uses, so a typo costs the
+ * opening hours but never the vendor.
+ */
+export const parseWorkingTime = (value: string): WorkingTime => {
+  const text = value.trim()
+  const lower = text.toLowerCase()
+
+  if (lower === '') return createDefaultWorkingTime()
+  if (lower === 'g' || lower === 'ganztags') return wholeWeek()
+
+  if (lower === 'v' || lower === 'vormittag' || lower === 'vormittags') {
+    return everyday('08:00', '12:00')
+  }
+
+  if (lower === 'n' || lower === 'nachmittag' || lower === 'nachmittags') {
+    return everyday('13:00', '17:00')
+  }
+
+  const range = readTimeRange(text)
+  const days = readDays(text)
+
+  if (days.length === 0) {
+    return range ? { mode: 'everyday', everyday: [range] } : createDefaultWorkingTime()
+  }
+
+  // Every day of the week, all day long — that is what "ganztags" means.
+  if (!range && days.length === WEEK_DAYS.length) return wholeWeek()
+
+  const week_days: { [day: string]: TimeRange[] } = {}
+
+  for (const day of WEEK_DAYS) {
+    if (days.includes(day)) week_days[day] = [range ?? { full_day: true }]
+  }
+
+  return { mode: 'by_day', week_days }
+}
+
+/** Keeps structured working times as they are and reads written ones. */
+export const normalizeWorkingTime = (
+  workingTime: string | WorkingTime | null | undefined
+): WorkingTime => {
+  if (!workingTime) return createDefaultWorkingTime()
+  if (typeof workingTime === 'string') return parseWorkingTime(workingTime)
+
+  return workingTime
+}

--- a/src/views/backoffice/BackofficeVendorNew.vue
+++ b/src/views/backoffice/BackofficeVendorNew.vue
@@ -6,7 +6,7 @@ import type { Vendor } from '@/stores/vendor'
 import { vendorsStore } from '@/stores/vendor'
 import { ref } from 'vue'
 import IconCross from '@/components/icons/IconCross.vue'
-import { transformToFloat } from '@/utils/utils'
+import { downloadVendorCsvTemplate, parseVendorsCsv } from '@/utils/vendorCsv'
 
 const store = vendorsStore()
 const settingsStore = useSettingsStore()
@@ -101,65 +101,8 @@ const importCSV = async () => {
   input.onchange = async (event: any) => {
     const file = event.target.files[0]
     const text = await file.text()
-    const lines = text.split('\n')
 
-    const vendors: Array<Vendor> = lines.map((line: any, i: number) => {
-      if (i === 0) return null
-
-      //@ts-ignore
-      const [
-        PLZ,
-        Location,
-        Address,
-        Longitude,
-        Latitude,
-        WorkingTime,
-        LicenseID,
-        FirstName,
-        LastName,
-        Telephone,
-        Language,
-        RegistrationDate,
-        VendorSince,
-        Comment,
-        OnlineMap,
-        HasSmartphone,
-        HasBankAccount,
-        Debt
-      ] = line.split(';')
-
-      const Email = `${LicenseID}${settingsStore.settings.VendorEmailPostfix}`
-      return {
-        PLZ,
-        Location,
-        Address,
-        Longitude: Longitude === '' ? 0.1 : transformToFloat(Longitude),
-        Latitude: Latitude === '' ? 0.1 : transformToFloat(Latitude),
-        WorkingTime: WorkingTime === '' ? 'G' : WorkingTime,
-        LicenseID,
-        FirstName,
-        LastName,
-        Telephone,
-        Language,
-        RegistrationDate,
-        VendorSince,
-        Comment,
-        LastPayout: null,
-        UrlID: '',
-        OnlineMap: OnlineMap === 'Ja' || OnlineMap === 'ja' || OnlineMap === 'yes' ? true : false,
-        HasSmartphone:
-          HasSmartphone === 'Ja' || HasSmartphone === 'ja' || HasSmartphone === 'yes'
-            ? true
-            : false,
-        HasBankAccount:
-          HasBankAccount === 'Ja' || HasBankAccount === 'ja' || HasBankAccount === 'yes'
-            ? true
-            : false,
-        IsDisabled: false,
-        Email,
-        Debt
-      }
-    })
+    const vendors = parseVendorsCsv(text, settingsStore.settings.VendorEmailPostfix)
 
     try {
       importing.value = true
@@ -397,11 +340,11 @@ const importCSV = async () => {
           {{ $t('menuVendors') }}
         </div>
       </div>
-      <footer>
-        <button
-          className="p-3 rounded-full customcolor fixed bottom-10 right-10 h-20 w-20"
-          @click="importCSV"
-        >
+      <footer class="fixed bottom-10 right-10 flex flex-col items-end gap-3">
+        <button class="p-3 rounded-full customcolor" @click="downloadVendorCsvTemplate">
+          {{ $t('downloadDemoCSV') }}
+        </button>
+        <button class="p-3 rounded-full customcolor h-20 w-20" @click="importCSV">
           {{ $t('CSV import') }}
         </button>
       </footer>


### PR DESCRIPTION
# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Description

**Standplätze und Kommentare wurden beim CSV-Import verworfen.** Der Import hat die Spalten `Station/Supermarkt`, `Adresse`, `PLZ`, `Longitude`, `Latitude`, `Arbeitszeit` und `Kommentar` geparst und mit dem Vendor mitgeschickt — aber `POST /vendors/` kennt diese Felder nicht. Standplatz und Kommentar sind eigene Ressourcen, also sind beide stillschweigend verlorengegangen.

Der Import legt sie jetzt nach dem Anlegen über `/vendors/{id}/locations/` und `/vendors/{id}/comments/` an. Die Vendor-ID kommt aus der Antwort von `CreateVendor`. Schlägt einer der beiden Calls fehl, wird geloggt und weitergemacht statt abzubrechen — der Vendor existiert zu dem Zeitpunkt schon, ein Abbruch würde die restlichen Zeilen kosten. Bereits vorhandene Ausweisnummern werden wie bisher komplett übersprungen.

**Arbeitszeiten als echte Uhrzeiten.** `working_time` ist inzwischen ein strukturiertes Objekt, die CSV kannte aber nur die alten Buchstaben mit drei fest verdrahteten Zeiten. Akzeptiert werden jetzt:

| CSV | Ergebnis |
|---|---|
| `Mo-Fr 08:00-12:00` | `by_day`, mon–fri |
| `Di,Do 09:00-13:00` | `by_day`, tue + thu |
| `Mo-Mi,Sa 10:00-16:00` | `by_day`, gemischt |
| `Mo-Fr` | `by_day`, ganze Tage |
| `09:00-17:00` | `everyday` |
| `Mo-So`, `ganztags`, `G` | `whole_week` |
| `V` / `N` | `everyday` 08:00–12:00 / 13:00–17:00 |

Deutsche und englische Tagesnamen, `:` und `.` als Trenner, einstellige Stunden (`8.00` → `08:00`). Unlesbare Zellen fallen auf den Default 09:00–17:00 zurück, statt die Zeile scheitern zu lassen. Die alten Buchstaben funktionieren weiter, damit bestehende Importdateien nicht brechen. Die Umsetzung lag bisher in `AddressModal` und liegt jetzt in `utils/workingTime.ts`, genutzt von beiden.

**Demo-CSV.** `Vendor_import.csv` mit 12 Verkäufer:innen, die jede akzeptierte Schreibweise abdecken, plus einen Button im Vendor-Formular zum Herunterladen. Die Datei bekommt beim Download ein UTF-8-BOM, damit Excel die Umlaute richtig anzeigt. Die alte Beispieldatei aus der Git-History hatte nur 17 Spalten und damit ein verschobenes `Debt`-Feld.

**Zwei Fehler, die beim Testen mit einer echten Datei aufgefallen sind:**

- Leerzeilen werden übersprungen. Der abschließende Zeilenumbruch, den jeder CSV-Editor schreibt, hat eine Zeile ohne Ausweisnummer erzeugt — und `createVendors` bricht bei so einer Zeile mit `return null` den ganzen Import ab. Mit der alten Ein-Zeilen-Beispieldatei war das unsichtbar.
- Zellen werden getrimmt. Bei CRLF-Dateien aus Excel landete sonst ein `\r` in der letzten Spalte, und `A-201 ` wurde zur Mailadresse `A-201 @augustin.or.at`.

Die Parsing-Logik lag im Callback des Datei-Dialogs und war damit nicht erreichbar; sie liegt jetzt in `utils/vendorCsv.ts`.

Der Footer-Button benutzte `className=` statt `class=` (React-Schreibweise), Vue rendert das als unbekanntes Attribut — das Styling hat also nie gegriffen. Beide Buttons liegen jetzt in einem `class`-Container, der Import-Button sieht dadurch anders aus als vorher. Ausserdem hatte `CSV import` gar keinen Locale-Eintrag und wurde als roher Key angezeigt.

## Bekannte Einschränkung

Pro Zelle geht nur ein Zeitbereich. `Mo-Fr 08:00-12:00 und 14:00-18:00` lässt sich nicht ausdrücken, weil `;` schon der CSV-Trenner ist und `,` die Tagesliste trennt. Das Datenmodell könnte mehrere Bereiche pro Tag, die CSV kann es nicht — geteilte Schichten müssen nach dem Import in der Maske nachgetragen werden.

Der Import legt ausserdem nur neu an. Standplätze und Kommentare bereits vorhandener Verkäufer:innen werden nicht aktualisiert, weil bekannte Ausweisnummern komplett übersprungen werden.

# Checklist:

- [x] I have commented my code (or ChatGPT did), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings, neither in my IDE nor in my browser
- [x] I have added tests that prove my fix is effective or that my feature works

34 Tests, `yarn type-check` und `yarn format` sauber, keine neuen Lint-Errors. Die Tests laufen gegen die ausgelieferte `Vendor_import.csv` selbst, damit Beispieldatei und Parser nicht auseinanderdriften. Gegengeprüft per Mutation: entfernt man den Standplatz-/Kommentar-Call, fallen 4 Tests um; entfernt man die `whole_week`-Normalisierung, 2; verschiebt man eine Spalte im Parser, 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)